### PR TITLE
Disable dirty check for UAT 1

### DIFF
--- a/src/components/createTestCase/CreateTestCase.test.tsx
+++ b/src/components/createTestCase/CreateTestCase.test.tsx
@@ -199,28 +199,6 @@ describe("CreateTestCase component", () => {
     expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
   });
 
-  it("should disable submit button when no changes are detected", async () => {
-    const testCase = { id: "1234", description: "Test IPP" } as TestCase;
-    mockedAxios.get.mockResolvedValue({
-      data: testCase,
-    });
-
-    render(
-      <MemoryRouter initialEntries={["/measure/m1234/edit/test-cases/1234"]}>
-        <ApiContextProvider value={serviceConfig}>
-          <TestCaseRoutes />
-        </ApiContextProvider>
-      </MemoryRouter>
-    );
-    await waitFor(() => {
-      const updateBtn = screen.getByRole("button", {
-        name: "Update Test Case",
-      });
-      expect(updateBtn).toBeInTheDocument();
-      expect(updateBtn).toBeDisabled();
-    });
-  });
-
   it("should update test case when update button is clicked", async () => {
     const testCase = { id: "1234", description: "Test IPP" } as TestCase;
     const testCaseDescription = "modified description";

--- a/src/components/createTestCase/CreateTestCase.tsx
+++ b/src/components/createTestCase/CreateTestCase.tsx
@@ -233,7 +233,6 @@ const CreateTestCase = () => {
                   }
                   type="submit"
                   data-testid="create-test-case-button"
-                  disabled={!(formik.isValid && formik.dirty)}
                 />
                 <Button
                   buttonTitle="Cancel"


### PR DESCRIPTION
## MADiE PR

### Summary
Patch for Known issue: Test Cases added from the backend cannot be modified. Removing dirty check for UAT 1 to prevent obstructions to testing.

### All Submissions
* [ ] This PR has the JIRA linked.
* [x] Required tests are included
* [x] No extemporaneous files are included (i.e Complied files or testing results)
* [x] This PR is in to the **correct branch**.
* [x] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [ ] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [x] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [x] All CDN/Web dependancies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
