### PR TITLE
Checks to make sure population Values are available for test cases

### DIFF
--- a/src/api/CalculationService.ts
+++ b/src/api/CalculationService.ts
@@ -90,6 +90,7 @@ export class CalculationService {
   }
 
   private buildMeasureGroups(measure: Measure, measureResource: fhir4.Measure) {
+    // verify if measureGroup is created? if not Calculation will fail, so return to user specifying to add atleast one measureGroup
     measure.groups.map((group) => {
       const fhirMeasureGroup: fhir4.MeasureGroup = {};
       fhirMeasureGroup.population = this.buildMeasureGroup(group.population);

--- a/src/components/testCaseList/TestCaseList.tsx
+++ b/src/components/testCaseList/TestCaseList.tsx
@@ -92,13 +92,14 @@ const TestCaseList = () => {
           testCases.forEach((testCase) => {
             const { populationResults } = executionResults.find(
               (result) => result.patientId === testCase.id
-            ).detailedResults[0]; // Since we have only 1 population group
+            )?.detailedResults?.[0]; // Since we have only 1 population group
 
-            if (populationResults.length) {
-              const { populationValues } = testCase.groupPopulations[0];
+            const populationValues =
+              testCase?.groupPopulations?.[0]?.populationValues;
 
+            // executionStatus is set to false if any of the populationResults (calculation result) doesn't match with populationValues (Given from testCase)
+            if (populationResults && populationValues) {
               let executionStatus = true;
-              // executionStatus is set to false if any of the populationResults (calculation result) doesn't match with populationValues (Given from testCase)
               populationResults.forEach((populationResult) => {
                 if (executionStatus) {
                   const groupPopulation = populationValues.find(


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-4134](https://jira.cms.gov/browse/MAT-4134)
(Optional) Related Tickets:

### Summary

- The issue happens when testCases doesn't have populationValues.
- Population values are cleared out when Measure group scoring value is changed, as a result the populationValue is undefined. Added checks to verify that. So when populationValues are unavailable then Execution status will be "N/A".

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included
* [x] No extemporaneous files are included (i.e Complied files or testing results)
* [x] This PR is into the **correct branch**.
* [ ] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [ ] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
