### PR TITLE
[MAT-4880] Disable Run button until the execution deps are loaded

### DIFF
--- a/src/components/editTestCase/EditTestCase.test.tsx
+++ b/src/components/editTestCase/EditTestCase.test.tsx
@@ -2263,11 +2263,12 @@ describe("Measure Calculation ", () => {
     )) as HTMLInputElement;
     userEvent.clear(editor);
     await waitFor(() => expect(editor.value).toBe(""));
-    userEvent.paste(editor, `   `);
+    // paste is either including the original editor.value content or
+    //  somehow the cleared editor state is reverted to its original.
+    userEvent.paste(editor, "    ");
     await waitFor(() => expect(editor.value).toBeTruthy());
 
     const runButton = await screen.findByRole("button", { name: "Run Test" });
-    userEvent.click(runButton);
     await waitFor(async () => userEvent.click(runButton));
 
     userEvent.click(screen.getByTestId("highlighting-tab"));

--- a/src/components/editTestCase/EditTestCase.test.tsx
+++ b/src/components/editTestCase/EditTestCase.test.tsx
@@ -157,6 +157,8 @@ const renderWithRouter = (
             bundleState: [measureBundle, setMeasureBundle],
             valueSetsState: [valueSets, setValueSets],
             executionContextReady: true,
+            executing: false,
+            setExecuting: jest.fn(),
           }}
         >
           <Routes>

--- a/src/components/editTestCase/EditTestCase.tsx
+++ b/src/components/editTestCase/EditTestCase.tsx
@@ -670,17 +670,17 @@ const EditTestCase = () => {
                 Editor tab
               </div>
             ))}
-          {activeTab === "highlighting" && (
+          {activeTab === "highlighting" && !executing && (
             <CalculationResults
               calculationResults={populationGroupResults}
               calculationErrors={calculationErrors}
             />
           )}
-          {/* {activeTab === "highlighting" && executing && (
+          {activeTab === "highlighting" && executing && (
             <div style={{ display: "flex", justifyContent: "center" }}>
               <MadieSpinner style={{ height: 50, width: 50 }} />
             </div>
-          )} */}
+          )}
           {activeTab === "expectoractual" && (
             <ExpectedActual
               canEdit={canEdit}

--- a/src/components/editTestCase/EditTestCase.tsx
+++ b/src/components/editTestCase/EditTestCase.tsx
@@ -59,7 +59,7 @@ import CreateTestCaseNavTabs from "../createTestCase/CreateTestCaseNavTabs";
 import ExpectedActual from "../createTestCase/RightPanel/ExpectedActual/ExpectedActual";
 import "./EditTestCase.scss";
 import CalculationResults from "../createTestCase/calculationResults/CalculationResults";
-import { TextField } from "@madie/madie-design-system/dist/react";
+import { TextField, MadieSpinner } from "@madie/madie-design-system/dist/react";
 
 const FormErrors = tw.div`h-6`;
 const TestCaseForm = tw.form`m-3`;
@@ -196,7 +196,14 @@ const EditTestCase = () => {
     []
   );
 
-  const { measureState, bundleState, valueSetsState } = useExecutionContext();
+  const {
+    measureState,
+    bundleState,
+    valueSetsState,
+    executionContextReady,
+    executing,
+    setExecuting,
+  } = useExecutionContext();
   const [measure] = measureState;
   const [measureBundle] = bundleState;
   const [valueSets] = valueSetsState;
@@ -420,6 +427,7 @@ const EditTestCase = () => {
 
   const calculate = async (e) => {
     e.preventDefault();
+    setExecuting(true);
     setPopulationGroupResults(() => undefined);
     if (measure && measure.cqlErrors) {
       setCalculationErrors({
@@ -455,6 +463,8 @@ const EditTestCase = () => {
             "Test case execution was aborted because JSON could not be validated. If this error persists, please contact the help desk.",
         });
         return;
+      } finally {
+        setExecuting(false);
       }
     }
 
@@ -478,6 +488,8 @@ const EditTestCase = () => {
         status: "error",
         message: error.message,
       });
+    } finally {
+      setExecuting(false);
     }
   };
 
@@ -664,6 +676,11 @@ const EditTestCase = () => {
               calculationErrors={calculationErrors}
             />
           )}
+          {/* {activeTab === "highlighting" && executing && (
+            <div style={{ display: "flex", justifyContent: "center" }}>
+              <MadieSpinner style={{ height: 50, width: 50 }} />
+            </div>
+          )} */}
           {activeTab === "expectoractual" && (
             <ExpectedActual
               canEdit={canEdit}
@@ -853,7 +870,9 @@ const EditTestCase = () => {
                   _.isNil(measure?.groups) ||
                   measure?.groups.length === 0 ||
                   (!isJsonModified() && validationErrors?.length > 0) ||
-                  isEmptyTestCaseJsonString(editorVal)
+                  isEmptyTestCaseJsonString(editorVal) ||
+                  !executionContextReady ||
+                  executing
                 }
                 /*
                   if new test case


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-4880](https://jira.cms.gov/browse/MAT-4880)
(Optional) Related Tickets:

### Summary
- Remove the extra run button click in unit test
- Disable the single Run Test button until the execution dependencies have finished loading
- Display spinner on highlighting tab during execution to signal the highlighting being refreshed

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included
* [x] No extemporaneous files are included (i.e Complied files or testing results)
* [x] This PR is into the **correct branch**.
* [x] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [x] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
