### PR TITLE
[MAT-5295] Coverage Default Values

### DIFF
--- a/src/util/CoverageDefaultValueProcessor.ts
+++ b/src/util/CoverageDefaultValueProcessor.ts
@@ -1,0 +1,100 @@
+import { Coverage, Organization, Reference } from "fhir/r4";
+import _ from "lodash";
+
+/**
+ * Apply Default Values to Coverage Resources, or add a Default Coverage
+ * Resource if none present.
+ *
+ * For existing Coverage Resources:
+ *  Set Coverage.status to 'active'.
+ *  Set Coverage.beneficiary to the Patient Reference.
+ *  Add Coverage.payor Reference to the Default Organization Reference.
+ *  Add Organization Resource.
+ */
+const addCoverageValues = (testCaseJson: any, patientRef: Reference) => {
+  const hasCoverageResource = _.find(
+    testCaseJson.entry,
+    (e) => e.resource.resourceType === "Coverage"
+  );
+
+  if (hasCoverageResource) {
+    // set status -> active and payor ref on existing Coverages
+    testCaseJson.entry?.forEach((entry) => {
+      if (entry.resource?.resourceType === "Coverage") {
+        const coverage: Coverage = entry.resource;
+        coverage.status = "active";
+        coverage.beneficiary = patientRef;
+        coverage.payor.push({
+          reference: "Organization/123456",
+        });
+      }
+    });
+  } else {
+    testCaseJson.entry.push({
+      fullUrl: "http://coverage/1",
+      resource: { ...defaultCoverage, beneficiary: patientRef },
+    });
+  }
+
+  // add default Organization
+  // ignoring existing Organization Resources
+  testCaseJson.entry.push({
+    fullUrl: "http://Organization/123456",
+    resource: { ...defaultOrganization },
+  });
+};
+export default addCoverageValues;
+
+const defaultCoverage: Coverage = {
+  resourceType: "Coverage",
+  beneficiary: undefined,
+  id: "1",
+  meta: {
+    profile: [
+      "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-coverage",
+    ],
+  },
+  payor: [{ reference: "Organization/123456" }],
+  status: "active",
+};
+const defaultOrganization: Organization = {
+  resourceType: "Organization",
+  active: true,
+  address: [
+    {
+      use: "billing",
+      type: "postal",
+      line: ["P.O. Box 660044"],
+      city: "Dallas",
+      state: "TX",
+      postalCode: "75266-0044",
+      country: "USA",
+    },
+  ],
+  id: "123456",
+  identifier: [
+    {
+      use: "temp",
+      system: "urn:oid:2.16.840.1.113883.4.4",
+      value: "21-3259825",
+    },
+  ],
+  meta: {
+    profile: [
+      "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-organization",
+    ],
+  },
+  name: "Blue Cross Blue Shield of Texas",
+  telecom: [{ system: "phone", value: "(+1) 972-766-6900" }],
+  type: [
+    {
+      coding: [
+        {
+          system: "http://terminology.hl7.org/CodeSystem/organization-type",
+          code: "pay",
+          display: "Payer",
+        },
+      ],
+    },
+  ],
+};

--- a/src/util/DefaultValueProcessor.test.ts
+++ b/src/util/DefaultValueProcessor.test.ts
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import { addValues } from "./DefaultValueProcessor";
 
 describe("Modify JSON to add Default Values", () => {
@@ -53,5 +54,49 @@ describe("Modify JSON to add Default Values", () => {
     expect(results).toBeDefined();
 
     expect(results.length).toBe(1);
+  });
+
+  it("should set Coverage.payor Reference to the default Organization", () => {
+    const coverageJson = require("../mockdata/testcase_wo_coverage.json");
+    const resultJson: any = addValues(coverageJson);
+
+    expect(resultJson).toBeDefined();
+
+    const results = resultJson?.entry.filter((entry) => {
+      return (
+        entry.resource.resourceType === "Coverage" &&
+        entry.resource.payor[0]?.reference === "Organization/123456"
+      );
+    });
+
+    expect(results).toBeDefined();
+    expect(results.length).toBe(1);
+
+    const organizations = resultJson?.entry.filter(
+      (entry) =>
+        entry.resource.resourceType === "Organization" &&
+        entry.resource.name === "Blue Cross Blue Shield of Texas"
+    );
+    expect(organizations).toHaveLength(1);
+    expect(organizations[0].resource.id).toBe("123456");
+  });
+
+  it("should set Coverage.beneficiary Reference to the Patient", () => {
+    const coverageJson = require("../mockdata/testcase_with_Coverage.json");
+    const resultJson = addValues(coverageJson);
+
+    const patientResource = _.find(
+      resultJson.entry,
+      (entry) => entry.resource.resourceType === "Patient"
+    ).resource;
+
+    resultJson?.entry?.forEach((entry) => {
+      if (entry.resource.resourceType === "Coverage") {
+        expect(entry.resource.beneficiary).toBeDefined();
+        expect(entry.resource.beneficiary.reference).toBe(
+          `Patient/${patientResource.id}`
+        );
+      }
+    });
   });
 });

--- a/src/util/DefaultValueProcessor.ts
+++ b/src/util/DefaultValueProcessor.ts
@@ -1,35 +1,21 @@
 import * as _ from "lodash";
+import { Reference } from "fhir/r4";
+import addCoverageValues from "./CoverageDefaultValueProcessor";
+import addEncounterValues from "./EncounterDefaultValueProcessor";
 
 export const addValues = (testCase: any): any => {
-  //create a clone of testCase
+  // create a clone of testCase
   const resultJson: any = _.cloneDeep(testCase);
-  //.map to return an array of just
-  const nonCoverage: Array<any> = resultJson.entry.filter((entry) => {
-    if (entry.resource?.resourceType !== "Coverage") {
-      return true;
-    }
-  });
 
-  const coverage: Array<any> = [];
-  const foundCoverage: Array<any> = resultJson.entry?.filter((entry) => {
-    if (entry.resource?.resourceType === "Coverage") {
-      entry.resource.status = "active";
-      return entry;
-    }
-  });
+  // safe to assume single Patient within the Bonnie Export bundle.
+  const patientId = _.find(
+    resultJson.entry,
+    (entry) => entry.resource.resourceType === "Patient"
+  ).resource.id;
+  const patientRef: Reference = { reference: `Patient/${patientId}` };
 
-  if (foundCoverage && foundCoverage.length > 0) {
-    coverage.push(...foundCoverage);
-  } else {
-    //TODO  This isn't sufficient.  The Added Coverage needs a Payor with an Organization.. can modify this when we address the additional stories
-    const defaultCoverage: any = JSON.parse(
-      '{"fullUrl":"http://local/Coverage/1","resource":{"resourceType":"Coverage","id":"example","meta":{"profile":["http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-coverage"]},"text":{"status":"generated","div":""},"status":"active","type":{"coding":[{"system":"https://nahdo.org/sopt","code":"59","display":"OtherPrivateInsurance"}]},"beneficiary":{"reference":"Patient/example"},"payor":[{"reference":"Organization/example"}]}}'
-    );
-    coverage.push(defaultCoverage);
-  }
+  addCoverageValues(resultJson, patientRef);
+  addEncounterValues(resultJson);
 
-  const entries = nonCoverage.concat(coverage);
-
-  resultJson.entry = entries;
   return resultJson;
 };

--- a/src/util/EncounterDefaultValueProcessor.ts
+++ b/src/util/EncounterDefaultValueProcessor.ts
@@ -1,0 +1,3 @@
+const addEncounterValues = (testCaseJson: any) => {};
+
+export default addEncounterValues;


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-5295](https://jira.cms.gov/browse/MAT-5295)
(Optional) Related Tickets:

### Summary
Apply Default Values to Coverage Resources, or add a Default Coverage Resource if none present.

For existing Coverage Resources:
 Set Coverage.status to 'active'.
 Set Coverage.beneficiary to the Patient Reference.
 Add Coverage.payor Reference to the Default Organization Reference.
 Add Organization Resource.

Set up scaffolding for parallel development of default value processors.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included
* [x] No extemporaneous files are included (i.e Complied files or testing results)
* [x] This PR is into the **correct branch**.
* [x] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [x] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
