### PR TITLE
[MAT-5299] Always add a Default Practitioner Resource

### DIFF
--- a/src/util/DefaultValueProcessor.test.ts
+++ b/src/util/DefaultValueProcessor.test.ts
@@ -212,7 +212,7 @@ describe("Modify JSON to add Default Values", () => {
     expect(results).toBe(beforeDefaultValuesJson);
   });
 
-  it("Should set identifier and name attributes to Practitioner", () => {
+  it("Should add a default Practitioner resource", () => {
     const defaultFamilyName = "Evil";
     const defaultPrefix = "Dr";
     const defaultIdentifierSystem = "http://hl7.org/fhir/sid/us-npi";
@@ -224,42 +224,31 @@ describe("Modify JSON to add Default Values", () => {
     );
 
     expect(updatedTestCaseWithDefaults).toBeDefined();
-    const practitioners: Practitioner[] = [];
-    _.forEach(
-      updatedTestCaseWithDefaults?.entry,
-      (entry) =>
-        entry.resource?.resourceType === "Practitioner" &&
-        practitioners.push(entry.resource)
+    const practitionerEntries = updatedTestCaseWithDefaults.entry.filter(
+      (entry) => {
+        return entry.resource?.resourceType === "Practitioner";
+      }
     );
-    expect(practitioners.length).toBe(4);
+    expect(practitionerEntries.length).toBe(5);
 
-    // Nothing should be changed for 1st practitioner
-    expect(practitioners[0].name[0].family).toBe("Careful");
-    expect(practitioners[0].name[0].prefix[0]).toBe("Dr");
-    expect(practitioners[0].identifier[0].system).toBe(
-      "urn:oid:2.16.840.1.113883.4.336"
+    const defaultPractitioners = practitionerEntries.filter((p) => {
+      return _.find(p.resource.identifier, ["value", "123456"]) !== undefined;
+    });
+
+    expect(defaultPractitioners).toHaveLength(1);
+
+    expect(defaultPractitioners[0].resource.name[0].family).toBe(
+      defaultFamilyName
     );
-    expect(practitioners[0].identifier[0].value).toBe("Practitioner-23");
-
-    // name and identifier defaults are added to 2nd practitioner
-    expect(practitioners[1].name[0].family).toBe(defaultFamilyName);
-    expect(practitioners[1].name[0].prefix[0]).toBe(defaultPrefix);
-    expect(practitioners[1].identifier[0].system).toBe(defaultIdentifierSystem);
-    expect(practitioners[1].identifier[0].value).toBe(defaultIdentifierValue);
-
-    // only default name is added to 3rd practitioner
-    expect(practitioners[2].name[0].family).toBe(defaultFamilyName);
-    expect(practitioners[2].name[0].prefix[0]).toBe(defaultPrefix);
-    expect(practitioners[2].identifier[0].system).toBe(
-      "urn:oid:2.16.840.1.113883.4.336"
+    expect(defaultPractitioners[0].resource.name[0].prefix[0]).toBe(
+      defaultPrefix
     );
-    expect(practitioners[2].identifier[0].value).toBe("Practitioner-23");
-
-    // only default identifier is added to 4th practitioner
-    expect(practitioners[3].name[0].family).toBe("Careful");
-    expect(practitioners[3].name[0].prefix[0]).toBe("Dr");
-    expect(practitioners[3].identifier[0].system).toBe(defaultIdentifierSystem);
-    expect(practitioners[3].identifier[0].value).toBe(defaultIdentifierValue);
+    expect(defaultPractitioners[0].resource.identifier[0].system).toBe(
+      defaultIdentifierSystem
+    );
+    expect(defaultPractitioners[0].resource.identifier[0].value).toBe(
+      defaultIdentifierValue
+    );
   });
 
   it("should set Device.patient to Patient Reference", () => {
@@ -285,7 +274,7 @@ describe("Modify JSON to add Default Values", () => {
 
   it("should set all the Procedure entries with status and subject properties", () => {
     const serviceRequestJson = require("../mockdata/testcase_with_Procedure.json");
-    const beforeDefaultValuesJson: any = _.cloneDeep(
+    const beforeProcedureCount: any = _.cloneDeep(
       serviceRequestJson
     )?.entry.filter(
       (entry) => entry.resource.resourceType === "Procedure"
@@ -293,14 +282,14 @@ describe("Modify JSON to add Default Values", () => {
 
     const resultJson: any = addValues(serviceRequestJson);
     expect(resultJson).toBeDefined();
-    let results = resultJson?.entry.filter((entry) => {
+    let afterProcedureCount = resultJson?.entry.filter((entry) => {
       return (
         entry.resource?.resourceType === "Procedure" &&
         entry.resource?.status &&
         entry.resource?.subject
       );
     }).length;
-    expect(results).toBe(beforeDefaultValuesJson);
+    expect(afterProcedureCount).toEqual(beforeProcedureCount);
   });
 
   it("should set MedicationAdministration.subject to Patient Reference", () => {

--- a/src/util/DefaultValueProcessor.ts
+++ b/src/util/DefaultValueProcessor.ts
@@ -62,11 +62,6 @@ export const addValues = (testCase: any): any => {
             patientRef
           ),
         };
-      case "Practitioner":
-        return {
-          ...entry,
-          resource: addingDefaultPractitionerProperties(entry?.resource),
-        };
       case "Encounter":
         return {
           ...entry,
@@ -76,30 +71,33 @@ export const addValues = (testCase: any): any => {
         return entry;
     }
   });
-
   addCoverageValues(resultJson, patientRef);
+  addPractitionerValues(resultJson);
 
   return resultJson;
 };
 
-const addingDefaultPractitionerProperties = (practitioner: Practitioner) => {
-  if (!practitioner?.name) {
-    practitioner.name = [
-      {
-        family: "Evil",
-        prefix: ["Dr"],
-      },
-    ];
-  }
-  if (!practitioner?.identifier) {
-    practitioner.identifier = [
-      {
-        system: "http://hl7.org/fhir/sid/us-npi",
-        value: "123456",
-      },
-    ];
-  }
-  return practitioner;
+const addPractitionerValues = (testCaseJson) => {
+  testCaseJson.entry.push({
+    fullUrl: "http://Practitioner/123456",
+    resource: {
+      resourceType: "Practitioner",
+      id: "practitioner-123456",
+      name: [
+        {
+          family: "Evil",
+          prefix: ["Dr"],
+        },
+      ],
+      identifier: [
+        {
+          system: "http://hl7.org/fhir/sid/us-npi",
+          value: "123456",
+        },
+      ],
+    },
+  });
+  return testCaseJson;
 };
 
 const addingDefaultMedicationOrServiceRequestProperties = (


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-5299](https://jira.cms.gov/browse/MAT-5299)
(Optional) Related Tickets:

### Summary

Rework: Instead of modifying existing Practitioner resources, add a default one when applying Default Values. Any existing Practitioner resources are now ignored.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included
* [x] No extemporaneous files are included (i.e Complied files or testing results)
* [x] This PR is into the **correct branch**.
* [x] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [x] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
