### PR TITLE
[MAT-5361] Use Coverage Calculation generated by fqm-execution

### DIFF
--- a/src/api/CalculationService.test.ts
+++ b/src/api/CalculationService.test.ts
@@ -295,60 +295,6 @@ describe("CalculationService Tests", () => {
     expect(output["P111"]["group1"]["denomDef"]).toBeFalsy();
   });
 
-  it("calculates overall coverage for a selected group when coverage info not available", () => {
-    // No groups provided
-    let overallCoverage = calculationService.getCoveragePercentageForGroup(
-      "id-123",
-      undefined
-    );
-    expect(overallCoverage).toBe(0);
-    // Empty group Array
-    overallCoverage = calculationService.getCoveragePercentageForGroup(
-      "id-123",
-      []
-    );
-    expect(overallCoverage).toBe(0);
-
-    // selected group missing clauseResults
-    overallCoverage = calculationService.getCoveragePercentageForGroup(
-      "633dae976efe1b323e5bf3d3",
-      groupResults
-    );
-    expect(overallCoverage).toBe(0);
-
-    // selected group not present in groupResults
-    overallCoverage = calculationService.getCoveragePercentageForGroup(
-      "invalid-group-id",
-      groupResults
-    );
-    expect(overallCoverage).toBe(0);
-  });
-
-  it("calculates overall coverage for a selected group when coverage info available", () => {
-    let overallCoverage = calculationService.getCoveragePercentageForGroup(
-      "633dae796efe1b323e5bf3a8",
-      groupResults
-    );
-    expect(overallCoverage).toBe(66);
-
-    overallCoverage = calculationService.getCoveragePercentageForGroup(
-      "633dae976efe1b323e5bf3a9",
-      groupResults
-    );
-    expect(overallCoverage).toBe(83);
-  });
-
-  it("test isClauseIgnored", () => {
-    const clause = {};
-    clause["raw"] = { name: "something" };
-    expect(calculationService.isClauseIgnored(clause)).toBeFalsy();
-
-    clause["final"] = "NA";
-    expect(calculationService.isClauseIgnored(clause)).toBeTruthy();
-    clause["raw"] = { name: "ValueSet" };
-    expect(calculationService.isClauseIgnored(clause)).toBeTruthy();
-  });
-
   describe("CalculationService.isValuePass", () => {
     it("should pass two blanks", () => {
       const output = calculationService.isValuePass("", "", false);


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-5631](https://jira.cms.gov/browse/MAT-5631)
(Optional) Related Tickets:

### Summary

The fqm-execution's coverage calculation differs from our calculation that was ported over from Bonnie. There's enough difference that users see conflicting results.

We're opting to use fqm-execution's coverage calculation because it aligns with the highlighting that is be is utilized in the tool, and this highlighting is heavily relied upon by the user base to determine which logic areas are missing coverage.

Currently, their coverage calculation result is only available in their Coverage HTML. This change re-works the regex used to locate this value so we can:
 1. Retrieve its numeric value from HTML.
 2. Remove the Coverage line from the HTML so it isn't appearing twice on the page.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included
* [x] No extemporaneous files are included (i.e Complied files or testing results)
* [x] This PR is into the **correct branch**.
* [x] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [ ] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [x] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [x] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
