### PR TITLE
MAT-5869:Modify negationRationale to only display when qdm status actions are present

### DIFF
--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsCard/DataElementsCard.tsx
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsCard/DataElementsCard.tsx
@@ -21,6 +21,26 @@ const DataElementsCard = (props: {
     selectedDataElement,
     setSelectedDataElement,
   } = props;
+  let negationRationale = false;
+  // https://ecqi.healthit.gov/mcw/2020/qdm-attribute/negationrationale.html  (list of all categories that use negation rationale)
+  // we want to display negation rationale only in instances where the cql uses a qdm status that references an action.
+  if (selectedDataElement && selectedDataElement?.qdmStatus) {
+    const status = selectedDataElement.qdmStatus;
+    if (status) {
+      const negationRationaleActions = {
+        order: true,
+        recommended: true,
+        performed: true,
+        communication: true,
+        dispensed: true,
+        applied: true,
+      };
+      if (negationRationaleActions[status] === true) {
+        negationRationale = true;
+      }
+    }
+  }
+
   // centralize state one level up so we can conditionally render our child component
   return (
     <div className="data-elements-card" data-testid="data-element-card">
@@ -58,6 +78,7 @@ const DataElementsCard = (props: {
       </div>
       {/* Govern our navigation for codes/att/negation */}
       <SubNavigationTabs
+        negationRationale={negationRationale}
         activeTab={cardActiveTab}
         setActiveTab={setCardActiveTab}
       />

--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsCard/DataElementsCard.tsx
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsCard/DataElementsCard.tsx
@@ -21,25 +21,9 @@ const DataElementsCard = (props: {
     selectedDataElement,
     setSelectedDataElement,
   } = props;
-  let negationRationale = false;
+  const negationRationale =
+    selectedDataElement?.hasOwnProperty("negationRationale");
   // https://ecqi.healthit.gov/mcw/2020/qdm-attribute/negationrationale.html  (list of all categories that use negation rationale)
-  // we want to display negation rationale only in instances where the cql uses a qdm status that references an action.
-  if (selectedDataElement && selectedDataElement?.qdmStatus) {
-    const status = selectedDataElement.qdmStatus;
-    if (status) {
-      const negationRationaleActions = {
-        order: true,
-        recommended: true,
-        performed: true,
-        communication: true,
-        dispensed: true,
-        applied: true,
-      };
-      if (negationRationaleActions[status] === true) {
-        negationRationale = true;
-      }
-    }
-  }
 
   // centralize state one level up so we can conditionally render our child component
   return (

--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsCard/SubNavigationTabs.tsx
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsCard/SubNavigationTabs.tsx
@@ -7,30 +7,33 @@ import {
 } from "../../../../../../../icons";
 
 export interface NavTabProps {
+  negationRationale: Boolean;
   activeTab: string;
   setActiveTab: (value: string) => void;
 }
 
-const OPTIONS = [
-  {
-    label: "Codes",
-    value: "codes",
-    icon: CodesIcon,
-  },
-  {
-    label: "Attributes",
-    value: "attributes",
-    icon: AttributesIcon,
-  },
-  {
-    label: "Negation Rationale",
-    value: "negation_rationale",
-    icon: NegationRationaleIcon,
-  },
-];
-
 // this guy will have to be able to access state and update the values of state to show numbers such as [Codes (1)] later on. we will have to update matchers too
-const SubNavigationTabs = ({ activeTab, setActiveTab }) => {
+const SubNavigationTabs = ({ activeTab, setActiveTab, negationRationale }) => {
+  const OPTIONS = [
+    {
+      label: "Codes",
+      value: "codes",
+      icon: CodesIcon,
+    },
+    {
+      label: "Attributes",
+      value: "attributes",
+      icon: AttributesIcon,
+    },
+  ];
+  // only push if we need it
+  if (negationRationale) {
+    OPTIONS.push({
+      label: "Negation Rationale",
+      value: "negation_rationale",
+      icon: NegationRationaleIcon,
+    });
+  }
   return (
     <div className="tabs-container">
       <Tabs

--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/ElementsSection.test.tsx
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/ElementsSection.test.tsx
@@ -328,6 +328,7 @@ const testDataElements = [
     id: "6480f13e91f25700004059db",
     codeListId: "2.16.840.1.113883.3.3157.4048",
     description: "Device, Order: Cardiopulmonary Arrest",
+    negationRationale: true,
   },
 ];
 

--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/ElementsSection.test.tsx
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/ElementsSection.test.tsx
@@ -430,6 +430,9 @@ describe("ElementsSection allows card opening and closing", () => {
     await waitFor(() => {
       expect(getByTestId("data-element-card")).toBeInTheDocument();
     });
+    await waitFor(() => {
+      expect(queryByText("Negation Rationale")).not.toBeInTheDocument();
+    });
     const deviceTab = screen.getByTestId("elements-tab-device");
     expect(deviceTab).toBeInTheDocument();
     act(() => {
@@ -437,6 +440,15 @@ describe("ElementsSection allows card opening and closing", () => {
     });
     await waitFor(() => {
       expect(queryByText("Timing")).not.toBeInTheDocument();
+    });
+    const deviceDataType = screen.getByTestId(
+      "data-type-Device, Order: Cardiopulmonary Arrest"
+    );
+    act(() => {
+      fireEvent.click(deviceDataType);
+    });
+    await waitFor(() => {
+      expect(queryByText("Negation Rationale")).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
https://ecqi.healthit.gov/mcw/2020/qdm-attribute/negationrationale.html

## MADiE PR

Jira Ticket: [MAT-5869](https://jira.cms.gov/browse/MAT-5869)
(Optional) Related Tickets:

### Summary
Negation rationale tab should only be present when the selected element has a status conducive of an action that can be negated  per above link.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included
* [x] No extemporaneous files are included (i.e Complied files or testing results)
* [x] This PR is into the **correct branch**.
* [x] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [x] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
