### PR TITLE
[MAT-5908] Display Duplicate Test Case Name Error on Create and Edit

### DIFF
--- a/src/api/useTestCaseServiceApi.ts
+++ b/src/api/useTestCaseServiceApi.ts
@@ -9,6 +9,7 @@ import {
 import { useOktaTokens } from "@madie/madie-util";
 import { ScanValidationDto } from "./models/ScanValidationDto";
 import { addValues } from "../util/DefaultValueProcessor";
+import { MadieError } from "../util/Utils";
 
 export class TestCaseServiceApi {
   constructor(private baseUrl: string, private getAccessToken: () => string) {}
@@ -26,6 +27,9 @@ export class TestCaseServiceApi {
       );
       return response.data;
     } catch (err) {
+      if (err?.response?.status === 400) {
+        throw new Error(err.response.data.message);
+      }
       const message = `Unable to create new test case`;
       throw new Error(message);
     }
@@ -106,6 +110,9 @@ export class TestCaseServiceApi {
       );
       return response.data;
     } catch (err) {
+      if (err?.response?.status === 400) {
+        throw new MadieError(err.response.data.message);
+      }
       const message = `Unable to update test case`;
       throw new Error(message);
     }

--- a/src/components/editTestCase/qiCore/EditTestCase.tsx
+++ b/src/components/editTestCase/qiCore/EditTestCase.tsx
@@ -26,7 +26,7 @@ import {
 import useTestCaseServiceApi from "../../../api/useTestCaseServiceApi";
 import Editor from "../../editor/Editor";
 import { TestCaseValidator } from "../../../validators/TestCaseValidator";
-import { sanitizeUserInput } from "../../../util/Utils";
+import { MadieError, sanitizeUserInput } from "../../../util/Utils";
 import TestCaseSeries from "../../createTestCase/TestCaseSeries";
 import * as _ from "lodash";
 import { Ace } from "ace-builds";
@@ -431,10 +431,18 @@ const EditTestCase = (props: EditTestCaseProps) => {
 
       handleTestCaseResponse(updatedTestCase, "update");
     } catch (error) {
-      setAlert(() => ({
-        status: "error",
-        message: "An error occurred while updating the test case.",
-      }));
+      setAlert(() => {
+        if (error instanceof MadieError) {
+          return {
+            status: "error",
+            message: error.message,
+          };
+        }
+        return {
+          status: "error",
+          message: "An error occurred while updating the test case.",
+        };
+      });
       setErrors([...errors, "An error occurred while updating the test case."]);
     }
   };
@@ -594,12 +602,15 @@ const EditTestCase = (props: EditTestCaseProps) => {
     );
   }
 
+  // TODO: What's the diff between this function and "handleHapiOutcome"?
+  // do we need both?
   function hasValidHapiOutcome(testCase: TestCase) {
     return (
-      (_.isNil(testCase.hapiOperationOutcome) ||
-        testCase.hapiOperationOutcome.code === 200 ||
+      // Consider valid if no hapi outcome. Most likely the editor is empty.
+      _.isNil(testCase.hapiOperationOutcome) ||
+      ((testCase.hapiOperationOutcome.code === 200 ||
         testCase.hapiOperationOutcome.code === 201) &&
-      isHapiOutcomeIssueCodeInformational(testCase?.hapiOperationOutcome)
+        isHapiOutcomeIssueCodeInformational(testCase?.hapiOperationOutcome))
     );
   }
 

--- a/src/util/Utils.ts
+++ b/src/util/Utils.ts
@@ -32,3 +32,9 @@ export const isTestCasePopulationObservation = (
     population.name === PopulationType.DENOMINATOR_OBSERVATION
   );
 };
+
+export class MadieError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-5908](https://jira.cms.gov/browse/MAT-5908)
(Optional) Related Tickets:
[measure-service PR#427](https://github.com/MeasureAuthoringTool/measure-service/pull/427)

### Summary

Test Case names shall be unique across its Measure. Uniqueness is determined by doing a case insensitive and ignoring whitespace comparison of the Test Case Title + Series. The check is performed by the measure-service (See measure-service PR#427), which will return a 400 with the validation message if the supplied Test Case name is a duplicate.

The validation message will display as a Toast when attempting to create a new Test Case with an existing Test Case name, and as an Alert on the Details tab when attempting to modify an existing Test Case Name to another existing Name.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included
* [x] No extemporaneous files are included (i.e Complied files or testing results)
* [x] This PR is into the **correct branch**.
* [x] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [x] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
