### PR TITLE
MAT-6054: implement data elements warning, prevent edit

### DIFF
--- a/src/components/editTestCase/qdm/EditTestCase.tsx
+++ b/src/components/editTestCase/qdm/EditTestCase.tsx
@@ -295,12 +295,27 @@ const EditTestCase = () => {
     setDiscardDialogOpen(false);
   };
 
+  const [testCaseErrors, setTestCaseErrors] = useState([]);
+
+  const handleTestCaseErrors = (value) => {
+    setTestCaseErrors([value]);
+  };
+
+  //
+
   return (
     <>
       {qdmExecutionErrors && qdmExecutionErrors.length > 0 && (
         <StatusHandler
           error={true}
           errorMessages={qdmExecutionErrors}
+          testDataId="test_case_execution_errors"
+        />
+      )}
+      {testCaseErrors && (
+        <StatusHandler
+          error={true}
+          errorMessages={testCaseErrors}
           testDataId="test_case_execution_errors"
         />
       )}
@@ -314,7 +329,10 @@ const EditTestCase = () => {
           <div className="allotment-wrapper">
             <Allotment defaultSizes={[200, 100]} vertical={false}>
               <Allotment.Pane>
-                <LeftPanel canEdit={canEdit} />
+                <LeftPanel
+                  canEdit={canEdit}
+                  handleTestCaseErrors={handleTestCaseErrors}
+                />
               </Allotment.Pane>
               <Allotment.Pane>
                 <RightPanel

--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/DatElementActions.tsx
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/DatElementActions.tsx
@@ -1,16 +1,17 @@
 import React from "react";
-import { Popover } from "@madie/madie-design-system/dist/react";
+import DataElementsTablePopover from "./DataElementsTablePopover";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import "./DataElementsTable.scss";
 
 type DatElementMenuProps = {
   elementId: string;
+  canView: boolean;
   onDelete: Function;
   onView: Function;
 };
 
 export default function DatElementActions(props: DatElementMenuProps) {
-  const { elementId, onDelete, onView } = props;
+  const { elementId, canView, onDelete, onView } = props;
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
@@ -45,12 +46,13 @@ export default function DatElementActions(props: DatElementMenuProps) {
         <div>View</div>
         <ExpandMoreIcon />
       </button>
-      <Popover
+      <DataElementsTablePopover
         id={`view-element-menu-${elementId}`}
         anchorEl={anchorEl}
         optionsOpen={open}
-        onClose={handleClose}
+        handleClose={handleClose}
         canEdit={true}
+        canView={canView}
         editViewSelectOptionProps={{
           label: "View",
           toImplementFunction: viewDataElement,

--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/DataElementsTable.test.tsx
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/DataElementsTable.test.tsx
@@ -133,6 +133,11 @@ const dataElements = [
   },
 ];
 
+const allowedTypes = {
+  "QDM::EncounterPerformed": true,
+  "QDM::Diagnosis": true,
+};
+
 const renderDataElementsTable = (dataElements, onDelete = () => {}) => {
   return render(
     <QdmExecutionContextProvider
@@ -145,7 +150,11 @@ const renderDataElementsTable = (dataElements, onDelete = () => {}) => {
       }}
     >
       <QdmPatientProvider>
-        <DataElementsTable dataElements={dataElements} onDelete={onDelete} />
+        <DataElementsTable
+          dataElements={dataElements}
+          onDelete={onDelete}
+          allowedTypes={allowedTypes}
+        />
       </QdmPatientProvider>
     </QdmExecutionContextProvider>
   );

--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/DataElementsTable.tsx
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/DataElementsTable.tsx
@@ -21,6 +21,7 @@ interface DataElementTableProps {
   dataElements?: DataElement[];
   onView?: (dataElement: DataElement) => void;
   onDelete?: (id: string) => void;
+  allowedTypes: object;
 }
 
 interface ElementAttributeEntry {
@@ -40,6 +41,7 @@ const DataElementTable = ({
   dataElements = [],
   onDelete,
   onView,
+  allowedTypes,
 }: DataElementTableProps) => {
   const { cqmMeasureState } = useQdmExecutionContext();
   const [codeSystemMap, setCodeSystemMap] = useState({});
@@ -140,6 +142,7 @@ const DataElementTable = ({
           return (
             <DatElementActions
               elementId={el.id}
+              canView={allowedTypes.hasOwnProperty(el._type)}
               onDelete={onDelete}
               onView={(e) => {
                 // e.preventDefault();

--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/DataElementsTablePopover.tsx
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/DataElementsTablePopover.tsx
@@ -1,9 +1,8 @@
 import React from "react";
-// import Popover from "@mui/material/Popover";
 import { Popover } from "@mui/material";
 
 const DataElementsTablePopover = (props: {
-  id: String;
+  id: string;
   optionsOpen: boolean;
   anchorEl: any;
   handleClose: any;

--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/DataElementsTablePopover.tsx
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/DataElementsTablePopover.tsx
@@ -1,0 +1,124 @@
+import React from "react";
+// import Popover from "@mui/material/Popover";
+import { Popover } from "@mui/material";
+
+const DataElementsTablePopover = (props: {
+  id: String;
+  optionsOpen: boolean;
+  anchorEl: any;
+  handleClose: any;
+  canView: boolean;
+  canEdit: boolean;
+  editViewSelectOptionProps: any;
+  additionalSelectOptionProps?: any;
+  otherSelectOptionProps: any;
+}) => {
+  const {
+    id,
+    optionsOpen,
+    anchorEl,
+    handleClose,
+    canView,
+    canEdit,
+    editViewSelectOptionProps,
+    additionalSelectOptionProps,
+    otherSelectOptionProps,
+  } = props;
+  return (
+    <div>
+      <Popover
+        open={optionsOpen}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "right",
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "left",
+        }}
+        sx={{
+          ".MuiPopover-paper": {
+            boxShadow: "none",
+            overflow: "visible",
+            ".popover-content": {
+              border: "solid 1px #979797",
+              position: "relative",
+              marginTop: "16px",
+              marginLeft: "-70px",
+              borderRadius: "6px",
+              background: "#F7F7F7",
+              width: "115px",
+              "&::before": {
+                borderWidth: "thin",
+                position: "absolute",
+                top: "-8px",
+                left: "calc(50% - 8px)",
+                height: "16px",
+                width: "16px",
+                background: "#F7F7F7",
+                borderColor: "#979797 transparent transparent #979797",
+                content: '""',
+                transform: "rotate(45deg)",
+              },
+              ".btn-container": {
+                display: "flex",
+                flexDirection: "column",
+                padding: "10px 0",
+                button: {
+                  zIndex: 2,
+                  fontSize: 14,
+                  padding: "0px 12px",
+                  textAlign: "left",
+                  "&:hover": {
+                    backgroundColor: "rgba(0, 0, 0, 0.5)",
+                  },
+                },
+              },
+            },
+          },
+        }}
+      >
+        <div className="popover-content" data-testid="popover-content" id={id}>
+          <div className="btn-container">
+            {canView && (
+              <button
+                data-testid={editViewSelectOptionProps.dataTestId}
+                onClick={editViewSelectOptionProps.toImplementFunction}
+              >
+                {editViewSelectOptionProps.label}
+              </button>
+            )}
+            {additionalSelectOptionProps &&
+              additionalSelectOptionProps.map((res) => {
+                return (
+                  <button
+                    key={res.dataTestId}
+                    data-testid={res.dataTestId}
+                    onClick={res.toImplementFunction}
+                  >
+                    {res.label}
+                  </button>
+                );
+              })}
+            {canEdit &&
+              otherSelectOptionProps.map((res) => {
+                return (
+                  <button
+                    key={res.dataTestId}
+                    data-testid={res.dataTestId}
+                    onClick={res.toImplementFunction}
+                  >
+                    {res.label}
+                  </button>
+                );
+              })}
+          </div>
+        </div>
+      </Popover>
+    </div>
+  );
+};
+
+export default DataElementsTablePopover;

--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/ElementsTab.tsx
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/ElementsTab.tsx
@@ -9,7 +9,11 @@ import { useFormikContext } from "formik";
 import * as _ from "lodash";
 import { QDMPatient } from "cqm-models";
 
-const ElementsTab = ({ canEdit }) => {
+const ElementsTab = (props: {
+  canEdit: boolean;
+  handleTestCaseErrors: Function;
+}) => {
+  const { canEdit, handleTestCaseErrors } = props;
   const { state, dispatch } = useQdmPatient();
   const formik: any = useFormikContext();
   const lastJsonRef = useRef(null);
@@ -40,7 +44,7 @@ const ElementsTab = ({ canEdit }) => {
   return (
     <>
       <DemographicsSection canEdit={canEdit} />
-      <ElementsSection />
+      <ElementsSection handleTestCaseErrors={handleTestCaseErrors} />
     </>
   );
 };

--- a/src/components/editTestCase/qdm/LeftPanel/LeftPanel.tsx
+++ b/src/components/editTestCase/qdm/LeftPanel/LeftPanel.tsx
@@ -6,7 +6,11 @@ import ElementsTab from "./ElementsTab/ElementsTab";
 import { QdmPatientProvider } from "../../../../util/QdmPatientContext";
 import { useFormikContext } from "formik";
 
-const LeftPanel = (props: { canEdit: boolean }) => {
+const LeftPanel = (props: {
+  canEdit: boolean;
+  handleTestCaseErrors: Function;
+}) => {
+  const { canEdit, handleTestCaseErrors } = props;
   const [activeTab, setActiveTab] = useState<string>("elements");
   const formik: any = useFormikContext();
 
@@ -17,7 +21,12 @@ const LeftPanel = (props: { canEdit: boolean }) => {
       </div>
       <div className="panel-content">
         <QdmPatientProvider>
-          {activeTab === "elements" && <ElementsTab canEdit={props.canEdit} />}
+          {activeTab === "elements" && (
+            <ElementsTab
+              canEdit={canEdit}
+              handleTestCaseErrors={handleTestCaseErrors}
+            />
+          )}
           {activeTab === "json" && (
             <pre tw="text-sm">
               {formik.values?.json &&


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-6054](https://jira.cms.gov/browse/MAT-6054)
(Optional) Related Tickets:

### Summary

This PR adds a warning when data elements not present in the cql are available on the test case.
This pr restricts edit action from being used on those elements.
This pr also fixes a bug where there is no click away function on the data elements table popover to close it.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included
* [x] No extemporaneous files are included (i.e Complied files or testing results)
* [x] This PR is into the **correct branch**.
* [x] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [x] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
