### PR TITLE
Parse ELM Bugfix: Avoid re-assignment of function arg

### DIFF
--- a/src/api/ElmParser.test.ts
+++ b/src/api/ElmParser.test.ts
@@ -359,5 +359,13 @@ describe("CqmConversionService", () => {
       result.statements[0].children[0].children[0].children[0].children[1]
         .ref_id
     ).toEqual("14");
+
+    expect(
+      result.statements[1].children[0].children[0].children[0].children.length
+    ).toEqual(2);
+    expect(
+      result.statements[1].children[0].children[0].children[0].children[1]
+        .children[0].children.length
+    ).toEqual(3);
   });
 });

--- a/src/api/ElmParser.ts
+++ b/src/api/ElmParser.ts
@@ -70,14 +70,14 @@ function parseNode(node, localIdToTypeMap) {
       if (child?.r) {
         nodeType = localIdToTypeMap[child.r];
       }
-      node = parseNode(child, localIdToTypeMap);
+      let nextNode = parseNode(child, localIdToTypeMap);
       if (nodeType) {
-        node.node_type = nodeType;
+        nextNode["node_type"] = nodeType;
       }
       if (child.r) {
-        node.ref_id = child.r;
+        nextNode["ref_id"] = child.r;
       }
-      parsedNode.children.push(node);
+      parsedNode.children.push(nextNode);
     }
   });
   return parsedNode;


### PR DESCRIPTION
## MADiE PR

Jira Ticket: N/A
(Optional) Related Tickets:

### Summary

Re-assigning the `node` function argument was causing the outermost for loop to execute against the wrong clojure. Assigning the return from the recursive call to a fresh variable corrects this behavior. 

### All Submissions
* [ ] This PR has the JIRA linked.
* [x] Required tests are included
* [x] No extemporaneous files are included (i.e Complied files or testing results)
* [x] This PR is into the **correct branch**.
* [x] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [x] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
