### PR TITLE
MAT-6285 Adding a unique key for each tile in DataElements list as re…

### DIFF
--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/dataElementsList/DataElementsList.tsx
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/dataElementsList/DataElementsList.tsx
@@ -13,7 +13,7 @@ const DataElementsList = (props: {
   return (
     <div className="data-types" data-testid="data-elementslist-container">
       {availableDataElements?.map((element) => (
-        <div key={`element - ${element.qdmStatus}`}>
+        <div key={element.description}>
           <DataElementsTile
             element={element}
             setSelectedDataElement={setSelectedDataElement}


### PR DESCRIPTION
…act uses these keys to rerender required components, and element.qdmStatus is not an unique field

## MADiE PR

Jira Ticket: [MAT-6285](https://jira.cms.gov/browse/MAT-6285)
(Optional) Related Tickets:

### Summary
Bug fix on the dataElementsList is re-rendered, React uses keys to identify new changes in the list and will only re-render them.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included
* [ ] No extemporaneous files are included (i.e Complied files or testing results)
* [ ] This PR is into the **correct branch**.
* [ ] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [ ] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
