### PR TITLE
Feature/mat 5981

### DIFF
--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/DatElementActions.tsx
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/DatElementActions.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import DataElementsTablePopover from "./DataElementsTablePopover";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import "./DataElementsTable.scss";
+import { Button } from "@madie/madie-design-system/dist/react";
 
 type DatElementMenuProps = {
   elementId: string;
@@ -15,23 +16,25 @@ export default function DatElementActions(props: DatElementMenuProps) {
   const { elementId, canView, onDelete, onView, canEdit } = props;
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
-  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    event.preventDefault();
-    setAnchorEl(event.currentTarget);
-  };
-  const handleClose = () => {
-    setAnchorEl(null);
+
+  const handleViewButtonClick = (event: React.MouseEvent<HTMLElement>) => {
+    if (canEdit) {
+      event.preventDefault();
+      setAnchorEl(event.currentTarget);
+    } else {
+      onView();
+    }
   };
 
-  const viewDataElement = () => {
-    onView();
-    // handleClose();
+  const handleClose = () => {
+    setAnchorEl(null);
   };
 
   const deleteDataElement = () => {
     handleClose();
     onDelete(elementId);
   };
+
   const deleteElement = canEdit
     ? {
         label: "Delete",
@@ -42,18 +45,30 @@ export default function DatElementActions(props: DatElementMenuProps) {
 
   return (
     <div>
-      <button
-        id={`view-element-btn-${elementId}`}
-        data-testid={`view-element-btn-${elementId}`}
-        className="view-button"
-        aria-controls={open ? `view-element-menu-${elementId}` : undefined}
-        aria-haspopup="true"
-        aria-expanded={open ? "true" : undefined}
-        onClick={handleClick}
-      >
-        <div>View</div>
-        <ExpandMoreIcon />
-      </button>
+      {canEdit ? (
+        <Button
+          id={`view-element-btn-${elementId}`}
+          data-testid={`view-element-btn-${elementId}`}
+          className="view-with-dropdown-button"
+          aria-controls={open ? `view-element-menu-${elementId}` : undefined}
+          aria-haspopup="true"
+          aria-expanded={open ? "true" : undefined}
+          onClick={handleViewButtonClick}
+        >
+          <div>View</div>
+          <ExpandMoreIcon />
+        </Button>
+      ) : (
+        <Button
+          id={`view-element-btn-${elementId}`}
+          data-testid={`view-element-btn-${elementId}`}
+          onClick={handleViewButtonClick}
+          loading={!canView} //disabled state
+          variant="primary"
+        >
+          View
+        </Button>
+      )}
       <DataElementsTablePopover
         id={`view-element-menu-${elementId}`}
         anchorEl={anchorEl}
@@ -61,12 +76,14 @@ export default function DatElementActions(props: DatElementMenuProps) {
         handleClose={handleClose}
         canEdit={true}
         canView={canView}
-        editViewSelectOptionProps={{
-          label: "View",
-          toImplementFunction: viewDataElement,
-          dataTestId: `view-element-${elementId}`,
+        editSelectOptionProps={{
+          label: "Edit",
+          toImplementFunction: () => {
+            return onView();
+          },
+          dataTestId: `edit-element-${elementId}`,
         }}
-        otherSelectOptionProps={[deleteElement]}
+        additionalSelectOptionProps={[deleteElement]}
       />
     </div>
   );

--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/DataElementsTable.scss
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/DataElementsTable.scss
@@ -138,7 +138,7 @@ $header-weight: 500;
         }
       }
 
-      .view-button {
+      .view-with-dropdown-button {
         color: #242424;
         border: 1px solid #8c8c8c;
         border-radius: 4px;
@@ -155,14 +155,14 @@ $header-weight: 500;
 
         > div {
           border-right: solid 1px #8c8c8c;
-          padding: 8px 16px;
+          padding: 8px 20px 8px 4px;
           flex-direction: row;
           flex-grow: 1;
           height: 100%;
         }
 
         > svg {
-          margin: 0 6px;
+          margin: 0 8px;
         }
       }
     }

--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/DataElementsTable.tsx
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/DataElementsTable.tsx
@@ -147,8 +147,7 @@ const DataElementTable = ({
               canEdit={canEdit}
               canView={allowedTypes.hasOwnProperty(el._type)}
               onDelete={onDelete}
-              onView={(e) => {
-                // e.preventDefault();
+              onView={() => {
                 onView && onView(el);
               }}
             />

--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/DataElementsTable.tsx
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/DataElementsTable.tsx
@@ -11,9 +11,9 @@ import {
 } from "@tanstack/react-table";
 import useQdmExecutionContext from "../../../../../../routes/qdm/useQdmExecutionContext";
 import TimingCell from "./TimingCell";
-import DatElementActions from "./DatElementActions";
 import { generateAttributesToDisplay } from "../../../../../../../util/QdmAttributeHelpers";
 import AttributesCell from "./AttributesCell";
+import DataElementActions from "./dataElementActions/DataElementActions";
 
 const columnHelper = createColumnHelper<DataElement>();
 
@@ -142,7 +142,7 @@ const DataElementTable = ({
         cell: (info) => {
           const el = info.getValue();
           return (
-            <DatElementActions
+            <DataElementActions
               elementId={el.id}
               canEdit={canEdit}
               canView={allowedTypes.hasOwnProperty(el._type)}

--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/DataElementsTablePopover.tsx
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/DataElementsTablePopover.tsx
@@ -8,20 +8,18 @@ const DataElementsTablePopover = (props: {
   handleClose: any;
   canView: boolean;
   canEdit: boolean;
-  editViewSelectOptionProps: any;
+  editSelectOptionProps: any;
   additionalSelectOptionProps?: any;
-  otherSelectOptionProps: any;
 }) => {
+  // canView prop defines if the data Element is still available and is not deleted from CQL
   const {
     id,
     optionsOpen,
     anchorEl,
     handleClose,
     canView,
-    canEdit,
-    editViewSelectOptionProps,
+    editSelectOptionProps,
     additionalSelectOptionProps,
-    otherSelectOptionProps,
   } = props;
   return (
     <div>
@@ -83,26 +81,14 @@ const DataElementsTablePopover = (props: {
           <div className="btn-container">
             {canView && (
               <button
-                data-testid={editViewSelectOptionProps.dataTestId}
-                onClick={editViewSelectOptionProps.toImplementFunction}
+                data-testid={editSelectOptionProps.dataTestId}
+                onClick={editSelectOptionProps.toImplementFunction}
               >
-                {editViewSelectOptionProps.label}
+                {editSelectOptionProps.label}
               </button>
             )}
             {additionalSelectOptionProps &&
               additionalSelectOptionProps.map((res) => {
-                return (
-                  <button
-                    key={res.dataTestId}
-                    data-testid={res.dataTestId}
-                    onClick={res.toImplementFunction}
-                  >
-                    {res.label}
-                  </button>
-                );
-              })}
-            {canEdit &&
-              otherSelectOptionProps.map((res) => {
                 return (
                   <button
                     key={res.dataTestId}

--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/dataElementActions/DataElementActions.test.tsx
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/dataElementActions/DataElementActions.test.tsx
@@ -1,0 +1,72 @@
+import * as React from "react";
+import { render, screen, within } from "@testing-library/react";
+import DataElementActions from "./DataElementActions";
+import userEvent from "@testing-library/user-event";
+
+const mockOnDelete = jest.fn();
+const mockOnView = jest.fn();
+
+describe("DatElementActions", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("Should display only View action button for a non owner", () => {
+    render(
+      <DataElementActions
+        elementId={"exampleId"}
+        canView={true}
+        onDelete={mockOnDelete}
+        onView={mockOnView}
+        canEdit={false}
+      />
+    );
+
+    const viewButton = screen.getByRole("button", { name: "View" });
+    expect(viewButton).toBeInTheDocument();
+    userEvent.click(viewButton);
+    expect(mockOnView).toHaveBeenCalledTimes(1);
+  });
+
+  it("Should display View action button along with popover for the owner", async () => {
+    render(
+      <DataElementActions
+        elementId={"exampleId"}
+        canView={true}
+        onDelete={mockOnDelete}
+        onView={mockOnView}
+        canEdit={true}
+      />
+    );
+
+    const viewButton = screen.getByRole("button", { name: "View" });
+    expect(viewButton).toBeInTheDocument();
+    userEvent.click(viewButton);
+    const popOver = await screen.findByTestId("popover-content");
+    const editButton = within(popOver).getByRole("button", { name: "Edit" });
+    userEvent.click(editButton);
+    expect(mockOnView).toHaveBeenCalledTimes(1);
+  });
+
+  it("Should display the delete button if the user is owner and deletes a dataElement when clicked", async () => {
+    render(
+      <DataElementActions
+        elementId={"exampleId"}
+        canView={true}
+        onDelete={mockOnDelete}
+        onView={mockOnView}
+        canEdit={true}
+      />
+    );
+
+    const viewButton = screen.getByRole("button", { name: "View" });
+    expect(viewButton).toBeInTheDocument();
+    userEvent.click(viewButton);
+    const popOver = await screen.findByTestId("popover-content");
+    const deleteButton = within(popOver).getByRole("button", {
+      name: "Delete",
+    });
+    userEvent.click(deleteButton);
+    expect(mockOnDelete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/dataElementActions/DataElementActions.tsx
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/dataElementActions/DataElementActions.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import DataElementsTablePopover from "./DataElementsTablePopover";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import "./DataElementsTable.scss";
+import "../DataElementsTable.scss";
 import { Button } from "@madie/madie-design-system/dist/react";
+import DataElementsTablePopover from "./DataElementsTablePopover";
 
-type DatElementMenuProps = {
+type DataElementActionsProps = {
   elementId: string;
   canView: boolean;
   onDelete: Function;
@@ -12,7 +12,7 @@ type DatElementMenuProps = {
   canEdit: boolean;
 };
 
-export default function DatElementActions(props: DatElementMenuProps) {
+export default function DataElementActions(props: DataElementActionsProps) {
   const { elementId, canView, onDelete, onView, canEdit } = props;
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);

--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/dataElementActions/DataElementsTablePopover.tsx
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsTable/dataElementActions/DataElementsTablePopover.tsx
@@ -81,6 +81,7 @@ const DataElementsTablePopover = (props: {
           <div className="btn-container">
             {canView && (
               <button
+                key={editSelectOptionProps.dataTestId}
                 data-testid={editSelectOptionProps.dataTestId}
                 onClick={editSelectOptionProps.toImplementFunction}
               >


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-5981](https://jira.cms.gov/browse/MAT-5981)
(Optional) Related Tickets:

### Summary

- Edit Action button is added to edit previously added QDM DataElements
- For non owners, the popover menu option is removed, so it will be only a single button "View", on clicks opens the non-editable DataElementCard
- New Test suite is added for DE Table Actions

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included
* [x] No extemporaneous files are included (i.e Complied files or testing results)
* [x] This PR is into the **correct branch**.
* [x] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [x] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
