### PR TITLE
MAT-6908: determine relative url based on presence of measure groups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@mui/x-date-pickers": "^6.6.0",
         "@tailwindcss/forms": "^0.5.7",
         "@tanstack/match-sorter-utils": "^8.8.4",
-        "@tanstack/react-table": "^8.13.2",
+        "@tanstack/react-table": "^8.10.3",
         "ace-builds": "~1.4.13",
         "allotment": "^1.19.0",
         "axios": "^1.6.1",

--- a/src/components/testCaseLanding/common/TestCaseTable/TestCaseTable.tsx
+++ b/src/components/testCaseLanding/common/TestCaseTable/TestCaseTable.tsx
@@ -194,6 +194,7 @@ const TestCaseTable = (props: TestCaseTableProps) => {
         canEdit={canEdit}
         viewOrEdit={viewOrEdit}
         model={measure?.model}
+        groups={measure?.groups}
         selectedTestCase={selectedTestCase}
         anchorEl={anchorEl}
         optionsOpen={optionsOpen}

--- a/src/components/testCaseLanding/common/TestCaseTable/TestCaseTablePopover.tsx
+++ b/src/components/testCaseLanding/common/TestCaseTable/TestCaseTablePopover.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { Popover } from "@mui/material";
-import { TestCase } from "@madie/madie-models";
+import { Group, TestCase } from "@madie/madie-models";
 import { useNavigate } from "react-router-dom";
+import * as _ from "lodash";
 
 interface TestCaseTablePopoverProps {
   optionsOpen: boolean;
@@ -14,6 +15,7 @@ interface TestCaseTablePopoverProps {
   setOptionsOpen: Function;
   onCloneTestCase?: (testCase: TestCase) => void;
   model: string;
+  groups: Group[];
   setDeleteDialogModalOpen: Function;
 }
 
@@ -32,6 +34,10 @@ const TestCaseTablePopover = (props: TestCaseTablePopoverProps) => {
     onCloneTestCase,
     setDeleteDialogModalOpen,
   } = props;
+  const editTestCaseUrl = _.isEmpty(props.groups)
+    ? `../${selectedTestCase?.id}`
+    : `../../${selectedTestCase?.id}`;
+
   return (
     <Popover
       open={optionsOpen}
@@ -96,7 +102,7 @@ const TestCaseTablePopover = (props: TestCaseTablePopoverProps) => {
             aria-label={`${viewOrEdit}-test-case-${selectedTestCase?.title}`}
             data-testid={`view-edit-test-case-${selectedTestCase?.id}`}
             onClick={() => {
-              navigate(`../../${selectedTestCase?.id}`, { relative: "path" });
+              navigate(editTestCaseUrl, { relative: "path" });
               setOptionsOpen(false);
             }}
           >


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-6908](https://jira.cms.gov/browse/MAT-6908)
(Optional) Related Tickets:

### Summary
This PR fixes a bug introduced with the routing updates to include population criteria ID in the route.
If no population criteria exist on the measure, then the relative URL to the edit test case screen is slightly different.


### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included
* [x] No extemporaneous files are included (i.e Complied files or testing results)
* [x] This PR is into the **correct branch**.
* [ ] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [ ] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
