### PR TITLE
MAT-6825: Display family and givenNames instead of Id on test case import messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@lhncbc/ucum-lhc": "^5.0.0",
         "@madie/cql-antlr-parser": "^1.0.0",
         "@madie/madie-design-system": "^1.2.9",
-        "@madie/madie-models": "^1.3.46",
+        "@madie/madie-models": "^1.3.47",
         "@mui/icons-material": "^5.8.2",
         "@mui/lab": "^5.0.0-alpha.82",
         "@mui/material": "^5.6.2",
@@ -5214,9 +5214,9 @@
       "peer": true
     },
     "node_modules/@madie/madie-models": {
-      "version": "1.3.46",
-      "resolved": "https://registry.npmjs.org/@madie/madie-models/-/madie-models-1.3.46.tgz",
-      "integrity": "sha512-jPLPHwt0oM9HdvmodnyYXBZRt6RbGdOnYYEXMmYTjVV2m2Z6Zd9eKwgFHDFW3v+1+5vmHLi43G/CzJ6WLoIuag=="
+      "version": "1.3.47",
+      "resolved": "https://registry.npmjs.org/@madie/madie-models/-/madie-models-1.3.47.tgz",
+      "integrity": "sha512-NeWHWXuKaMw0PFYkdDxKe65kZHHQ+NP13G/jSPoFsKgdNofYkDdpaddYY/tBnHnJ1bnLmN4TCw+cUUvpwjSnqA=="
     },
     "node_modules/@mui/base": {
       "version": "5.0.0-alpha.113",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@lhncbc/ucum-lhc": "^5.0.0",
     "@madie/cql-antlr-parser": "^1.0.0",
     "@madie/madie-design-system": "^1.2.9",
-    "@madie/madie-models": "^1.3.46",
+    "@madie/madie-models": "^1.3.47",
     "@mui/icons-material": "^5.8.2",
     "@mui/lab": "^5.0.0-alpha.82",
     "@mui/material": "^5.6.2",

--- a/src/components/statusHandler/StatusHandler.test.tsx
+++ b/src/components/statusHandler/StatusHandler.test.tsx
@@ -4,7 +4,7 @@ import StatusHandler from "./StatusHandler";
 import { TestCaseImportOutcome } from "../../../../madie-models/src/TestCase";
 
 describe("StatusHandler Component", () => {
-  const { getByTestId, queryByTestId, getByText } = screen;
+  const { getByTestId, queryByTestId, getByText, findByText } = screen;
   test("Should display nothing when error is false", () => {
     render(
       <StatusHandler
@@ -96,5 +96,54 @@ describe("StatusHandler Component", () => {
     const importWarnings: TestCaseImportOutcome[] = [];
     render(<StatusHandler importWarnings={importWarnings} />);
     expect(screen.queryByTestId("failed-test-cases")).toBeNull();
+  });
+
+  it("displays success family + given names", async () => {
+    const successOutcomes: TestCaseImportOutcome[] = [
+      {
+        familyName: "Family1",
+        givenNames: ["Given1"],
+        patientId: "test.patientId",
+        message: "Error while processing Test Case Json.",
+        successful: true,
+      },
+      {
+        familyName: "Family2",
+        givenNames: [""],
+        patientId: "test.patientId2",
+        message:
+          "The measure populations do not match the populations in the import file. No expected values have been set.",
+        successful: true,
+      },
+    ];
+    render(<StatusHandler importWarnings={successOutcomes} />);
+    const name = await findByText("Family1 Given1");
+    expect(name).toBeInTheDocument();
+    const name1 = await findByText("test.patientId2");
+    expect(name1).toBeInTheDocument();
+  });
+  it("displays failure family + given names", async () => {
+    const failureOutcome: TestCaseImportOutcome[] = [
+      {
+        familyName: "Family1",
+        givenNames: ["Given1"],
+        patientId: "test.patientId",
+        message: "Error while processing Test Case Json.",
+        successful: false,
+      },
+      {
+        familyName: "Family2",
+        givenNames: [""],
+        patientId: "test.patientId2",
+        message:
+          "The measure populations do not match the populations in the import file. No expected values have been set.",
+        successful: false,
+      },
+    ];
+    render(<StatusHandler importWarnings={failureOutcome} />);
+    const name = await findByText("Family1 Given1");
+    expect(name).toBeInTheDocument();
+    const name1 = await findByText("test.patientId2");
+    expect(name1).toBeInTheDocument();
   });
 });

--- a/src/components/statusHandler/StatusHandler.tsx
+++ b/src/components/statusHandler/StatusHandler.tsx
@@ -80,9 +80,15 @@ const StatusHandler = ({
                 </h6>
                 <ul>
                   {failedImports.map((failedImport) => {
+                    const family = failedImport?.familyName;
+                    const given = failedImport?.givenNames?.toString();
+                    const names =
+                      family && given
+                        ? `${family} ${given}`
+                        : failedImport?.patientId;
                     return (
                       <li data-testid="failed-test-cases">
-                        {failedImport.patientId} <br />
+                        {names} <br />
                         <span tw="ml-4">Reason : {failedImport.message}</span>
                       </li>
                     );
@@ -98,9 +104,17 @@ const StatusHandler = ({
                     <ul>
                       {successfulImportsWithWarning.map(
                         (successfulImportWithWarning) => {
+                          const family =
+                            successfulImportWithWarning?.familyName;
+                          const given =
+                            successfulImportWithWarning?.givenNames?.toString();
+                          const names =
+                            family && given
+                              ? `${family} ${given}`
+                              : successfulImportWithWarning?.patientId;
                           return (
                             <li data-testid="success-imports-with-warnings">
-                              {successfulImportWithWarning.patientId}{" "}
+                              {names}{" "}
                             </li>
                           );
                         }


### PR DESCRIPTION
…port messages where present

## MADiE PR

Jira Ticket: [MAT-6825](https://jira.cms.gov/browse/MAT-6825)
(Optional) Related Tickets:

### Summary
Displaying newly generated random uuid's as descriptors for which test cases failed or have warnings is confusing.
This PR allows for displaying given and family names instead.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included
* [x] No extemporaneous files are included (i.e Complied files or testing results)
* [x] This PR is into the **correct branch**.
* [x] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [x] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
