### PR TITLE
MAT-6379: Prevent default qiCore validations from being called before measure state.

### DIFF
--- a/src/components/routes/EmptyRoutes.tsx
+++ b/src/components/routes/EmptyRoutes.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const EmptyRoutes = () => {
+  return <div></div>;
+};
+
+export default EmptyRoutes;

--- a/src/components/routes/RoutesWrapper.tsx
+++ b/src/components/routes/RoutesWrapper.tsx
@@ -11,13 +11,18 @@ const RoutesWrapper = () => {
     };
   }, []);
 
+  // If no model match, import an empty file to avoid calling validations early.
+  // Unsure of a more robust way to actively wait for the subscription of measure from dispatch at this time.
   const TestCaseRoutesComponent = useMemo(
     () =>
       lazy(() => {
         if (measure?.model.includes("QDM")) {
           return import("./qdm/TestCaseRoutes");
-        } else {
+        }
+        if (measure?.model.includes("QI-Core")) {
           return import("./qiCore/TestCaseRoutes");
+        } else {
+          return import("./EmptyRoutes");
         }
       }),
     [measure?.model]


### PR DESCRIPTION
… measure arrives

## MADiE PR

Jira Ticket: [MAT-6379](https://jira.cms.gov/browse/MAT-6379)
(Optional) Related Tickets:

### Summary

Previously test case routes component would default to qiCore when no measure was available. 
This caused unintended requests.

Modification is to instead return an empty div before measure.model is present.

This seems to conflict with the nature of lazy loading and suspense, which should render a loading div before an asynchronous action is complete. 

However attempting to use this pattern with rsjx convolutes the issue as there is no guarantee that there will be a measure stored at this value on load, making any kind of asynchronous wait call possibly fail. 

A possible mitigation to this would be multiple calls until something is present, but the solution of just adding a default empty route div seems less error prone.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included
* [x] No extemporaneous files are included (i.e Complied files or testing results)
* [x] This PR is into the **correct branch**.
* [x] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [x] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
