### PR TITLE
MAT-7075: remove option for Excel export for QI-Core

### DIFF
--- a/src/components/testCaseLanding/qiCore/CreateCodeCoverageNavTabs.tsx
+++ b/src/components/testCaseLanding/qiCore/CreateCodeCoverageNavTabs.tsx
@@ -208,13 +208,6 @@ export default function CreateCodeCoverageNavTabs(props: NavTabProps) {
           canEdit={canEdit}
           additionalSelectOptionProps={[
             {
-              label: "Excel",
-              dataTestId: `export-excel`,
-              toImplementFunction: () => {
-                exportTestCases("EXCEL");
-              },
-            },
-            {
               label: "Transaction Bundle",
               dataTestId: `export-transaction-bundle`,
               toImplementFunction: () => {


### PR DESCRIPTION
This option is supposed to be for QDM measures/test cases only

## MADiE PR

Jira Ticket: [MAT-7075](https://jira.cms.gov/browse/MAT-7075)
(Optional) Related Tickets:

### Summary

Removed the option for Excel export of test cases for QI-Core measures. This option was intended to be QDM only.
![image](https://github.com/MeasureAuthoringTool/madie-patient/assets/94391996/58b5b8ed-4173-4422-807f-40da68911866)

The option should still be present for QDM:
![image](https://github.com/MeasureAuthoringTool/madie-patient/assets/94391996/457f3aa3-e924-4aaa-ae23-f92a14556a57)


### All Submissions
* [x] This PR has the JIRA linked.
* [ ] Required tests are included
* [x] No extemporaneous files are included (i.e Complied files or testing results)
* [x] This PR is into the **correct branch**.
* [ ] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [ ] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
