### PR TITLE
[MAT-6990] Reset contextFailure when measure is updated

### DIFF
--- a/src/components/routes/qdm/TestCaseRoutes.tsx
+++ b/src/components/routes/qdm/TestCaseRoutes.tsx
@@ -42,6 +42,7 @@ const TestCaseRoutes = () => {
   }, []);
 
   useEffect(() => {
+    setContextFailure(null);
     const localErrors: Array<string> = [];
     if (measure) {
       if (measure.cqlErrors || !measure.elmJson) {


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-6990](https://jira.cms.gov/browse/MAT-6990)
(Optional) Related Tickets:

### Summary

The `contextFailure` prop is one of the checks used by the `Run Test(s)` button to determine  if it should be disabled or in loading state. 

It is also a catch all for bad things happening at the route level, which, until the inclusion of test case configuration, could only be resolved by leaving the component, making corrections, and returning, which would reset its state. Now the correction can occur inside madie-patient and so the prop needs to be reset when changes are made.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included
* [x] No extemporaneous files are included (i.e Complied files or testing results)
* [x] This PR is into the **correct branch**.
* [x] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [x] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
