### PR TITLE
[MAT-6835] Use custom DTOs for QRDA Export

### DIFF
--- a/src/api/TestCaseServiceApi.test.tsx
+++ b/src/api/TestCaseServiceApi.test.tsx
@@ -242,7 +242,7 @@ describe("TestCaseServiceApi Tests", () => {
     ];
     const qrdaData = await testCaseService.exportQRDA("testMeasureId", {
       measure: mockMeasure,
-      testCaseDtos,
+      groupDTOs: testCaseDtos,
     });
     expect(axios.put).toBeCalledTimes(1);
     expect(qrdaData).toEqual(zippedQRDAData);
@@ -262,7 +262,7 @@ describe("TestCaseServiceApi Tests", () => {
     try {
       await testCaseService.exportQRDA("testMeasureId", {
         measure: mockMeasure,
-        testCaseDtos,
+        groupDTOs: testCaseDtos,
       });
       expect(axios.put).toBeCalledTimes(1);
     } catch (error) {

--- a/src/api/useTestCaseServiceApi.ts
+++ b/src/api/useTestCaseServiceApi.ts
@@ -3,13 +3,23 @@ import useServiceConfig from "./useServiceConfig";
 import { ServiceConfig } from "./ServiceContext";
 import {
   HapiOperationOutcome,
+  Measure,
   TestCase,
+  TestCaseExcelExportDto,
   TestCaseImportRequest,
 } from "@madie/madie-models";
 import { useOktaTokens } from "@madie/madie-util";
 import { ScanValidationDto } from "./models/ScanValidationDto";
 import { addValues } from "../util/DefaultValueProcessor";
 import { MadieError } from "../util/Utils";
+
+export type QrdaRequestDTO = {
+  measure: Measure;
+  coveragePercentage: string;
+  passPercentage: number;
+  passFailRatio: string;
+  testCaseDtos: TestCaseExcelExportDto[];
+};
 
 export class TestCaseServiceApi {
   constructor(private baseUrl: string, private getAccessToken: () => string) {}
@@ -289,9 +299,13 @@ export class TestCaseServiceApi {
     fileReader.readAsText(file);
   }
 
-  async exportQRDA(measureId: string): Promise<Blob> {
-    const response = await axios.get(
+  async exportQRDA(
+    measureId: string,
+    requestDto: QrdaRequestDTO
+  ): Promise<Blob> {
+    const response = await axios.put(
       `${this.baseUrl}/measures/${measureId}/test-cases/qrda`,
+      requestDto,
       {
         headers: {
           Authorization: `Bearer ${this.getAccessToken()}`,

--- a/src/api/useTestCaseServiceApi.ts
+++ b/src/api/useTestCaseServiceApi.ts
@@ -15,9 +15,6 @@ import { MadieError } from "../util/Utils";
 
 export type QrdaRequestDTO = {
   measure: Measure;
-  coveragePercentage: string;
-  passPercentage: number;
-  passFailRatio: string;
   testCaseDtos: TestCaseExcelExportDto[];
 };
 

--- a/src/api/useTestCaseServiceApi.ts
+++ b/src/api/useTestCaseServiceApi.ts
@@ -2,20 +2,37 @@ import axios, { AxiosResponse } from "axios";
 import useServiceConfig from "./useServiceConfig";
 import { ServiceConfig } from "./ServiceContext";
 import {
+  GroupedStratificationDto,
   HapiOperationOutcome,
   Measure,
+  PopulationDto,
   TestCase,
-  TestCaseExcelExportDto,
   TestCaseImportRequest,
 } from "@madie/madie-models";
 import { useOktaTokens } from "@madie/madie-util";
 import { ScanValidationDto } from "./models/ScanValidationDto";
 import { addValues } from "../util/DefaultValueProcessor";
 import { MadieError } from "../util/Utils";
+import { TestCaseExecutionResultDto } from "@madie/madie-models/dist/TestCaseExcelExportDto";
+
+export interface QrdaTestCaseDTO {
+  testCaseId: string;
+  lastName: string;
+  firstName: string;
+  populations: Array<PopulationDto>;
+  stratifications?: Array<GroupedStratificationDto>;
+}
+
+export interface QrdaGroupExportDTO {
+  groupId: string;
+  groupNumber: string;
+  coverage: string;
+  testCaseDTOs: QrdaTestCaseDTO[];
+}
 
 export type QrdaRequestDTO = {
   measure: Measure;
-  testCaseDtos: TestCaseExcelExportDto[];
+  groupDTOs: QrdaGroupExportDTO[];
 };
 
 export class TestCaseServiceApi {

--- a/src/components/testCaseLanding/qdm/TestCaseList.tsx
+++ b/src/components/testCaseLanding/qdm/TestCaseList.tsx
@@ -2,15 +2,16 @@ import React, { useEffect, useRef, useState } from "react";
 import "twin.macro";
 import "styled-components/macro";
 import * as _ from "lodash";
+import { uniqWith } from "lodash";
 import {
   Group,
   MeasureErrorType,
   TestCase,
+  TestCaseExcelExportDto,
   TestCaseImportOutcome,
   TestCaseImportRequest,
-  TestCaseExcelExportDto,
 } from "@madie/madie-models";
-import { useParams, useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import calculationService from "../../../api/CalculationService";
 import { checkUserCanEdit, measureStore } from "@madie/madie-util";
 import CreateCodeCoverageNavTabs from "./CreateCodeCoverageNavTabs";
@@ -22,8 +23,8 @@ import {
 } from "@madie/madie-design-system/dist/react";
 import Typography from "@mui/material/Typography";
 import {
-  TestCasesPassingDetailsProps,
   TestCaseListProps,
+  TestCasesPassingDetailsProps,
 } from "../common/interfaces";
 import TestCaseTable from "../common/TestCaseTable/TestCaseTable";
 import UseTestCases from "../common/Hooks/UseTestCases";
@@ -37,10 +38,9 @@ import TestCaseCoverage from "./TestCaseCoverage/TestCaseCoverage";
 import { QDMPatient } from "cqm-models";
 import { cloneTestCase } from "../../../util/QdmTestCaseHelper";
 import {
-  GroupCoverageResult,
   buildHighlightingForAllGroups,
+  GroupCoverageResult,
 } from "../../../util/cqlCoverageBuilder/CqlCoverageBuilder";
-import { uniqWith } from "lodash";
 import { checkSpecialCharactersForExport } from "../../../util/checkSpecialCharacters";
 import { createExcelExportDtosForAllTestCases } from "../../../util/TestCaseExcelExportUtil";
 import useCqlParsingService from "../../../api/useCqlParsingService";
@@ -248,70 +248,66 @@ const TestCaseList = (props: TestCaseListProps) => {
       });
       setTestCases([...testCases]);
     }
-    clauseCoverageProcessor(calculationOutput);
+    setCoveragePercentage(clauseCoverageProcessor());
   }, [calculationOutput, selectedPopCriteria]);
 
-  const clauseCoverageProcessor = (calculationOutput) => {
-    //generates current populations coverage %
-    if (calculationOutput && selectedPopCriteria) {
-      let allClauses = [];
-      let relevantStatements;
-      const patientIDs = Object.keys(calculationOutput);
-      patientIDs.forEach((patientID) => {
-        let newClauseResults = [];
-        const clauseResults =
-          calculationOutput[patientID][selectedPopCriteria.id]?.clause_results;
-        if (clauseResults) {
-          newClauseResults = Object.values(
-            calculationOutput[patientID][selectedPopCriteria.id]?.clause_results
+  const clauseCoverageProcessor = (measureGroup?: Group): string => {
+    //generates populations' coverage %
+    if (!calculationOutput) {
+      return;
+    }
+    const group = measureGroup ?? selectedPopCriteria;
+    if (!group) {
+      return;
+    }
+    let allClauses = [];
+    let relevantStatements;
+    const patientIDs = Object.keys(calculationOutput);
+    patientIDs.forEach((patientID) => {
+      let newClauseResults = [];
+      const clauseResults =
+        calculationOutput[patientID][group.id]?.clause_results;
+      if (clauseResults) {
+        newClauseResults = Object.values(
+          calculationOutput[patientID][group.id]?.clause_results
+        )?.flatMap(Object.values);
+      }
+      // we only need one copy of relevantStatements from the first group to match against
+      if (!relevantStatements) {
+        const statementResults =
+          calculationOutput[patientID][group.id]?.statement_results;
+        if (statementResults) {
+          relevantStatements = Object.values(
+            calculationOutput[patientID][group.id]?.statement_results
           )?.flatMap(Object.values);
         }
-        // we only need one copy of relevantStatements from the first group to match against
-        if (!relevantStatements) {
-          const statementResults =
-            calculationOutput[patientID][selectedPopCriteria.id]
-              ?.statement_results;
-          if (statementResults) {
-            const newStatementResults = Object.values(
-              calculationOutput[patientID][selectedPopCriteria.id]
-                ?.statement_results
-            )?.flatMap(Object.values);
-            relevantStatements = newStatementResults;
-          }
-        }
-        allClauses = [...allClauses, ...newClauseResults];
-      });
-      // get a list of used statements
-      relevantStatements = relevantStatements.filter(
-        (s) => s.relevance !== "NA"
-      );
-      const allRelevantClauses = allClauses
-        .filter((c) =>
-          relevantStatements.some(
-            (s) =>
-              s.statementName === c.statementName &&
-              s.libraryName === c.libraryName
-          )
+      }
+      allClauses = [...allClauses, ...newClauseResults];
+    });
+    // get a list of used statements
+    relevantStatements = relevantStatements.filter((s) => s.relevance !== "NA");
+    const allRelevantClauses = allClauses
+      .filter((c) =>
+        relevantStatements.some(
+          (s) =>
+            s.statementName === c.statementName &&
+            s.libraryName === c.libraryName
         )
-        .filter((result) => result.final !== "NA");
-      // get a list of all unique used clauses
-      const allUniqueClauses = uniqWith(
-        allRelevantClauses,
-        (c1, c2) =>
-          c1.libraryName === c2.libraryName && c1.localId === c2.localId
-      ).sort((a, b) => a.localId - b.localId);
-      // get a list of all unique covered clauses
-      const coveredClauses = uniqWith(
-        allRelevantClauses.filter((clause) => clause.final === "TRUE"),
-        (c1, c2) =>
-          c1.libraryName === c2.libraryName && c1.localId === c2.localId
-      );
-      setCoveragePercentage(
-        Math.floor(
-          (coveredClauses.length / allUniqueClauses.length) * 100
-        ).toString()
-      );
-    }
+      )
+      .filter((result) => result.final !== "NA");
+    // get a list of all unique used clauses
+    const allUniqueClauses = uniqWith(
+      allRelevantClauses,
+      (c1, c2) => c1.libraryName === c2.libraryName && c1.localId === c2.localId
+    ).sort((a, b) => a.localId - b.localId);
+    // get a list of all unique covered clauses
+    const coveredClauses = uniqWith(
+      allRelevantClauses.filter((clause) => clause.final === "TRUE"),
+      (c1, c2) => c1.libraryName === c2.libraryName && c1.localId === c2.localId
+    );
+    return Math.floor(
+      (coveredClauses.length / allUniqueClauses.length) * 100
+    ).toString();
   };
   const createNewTestCase = () => {
     setCreateOpen(true);

--- a/src/components/testCaseLanding/qdm/TestCaseList.tsx
+++ b/src/components/testCaseLanding/qdm/TestCaseList.tsx
@@ -5,7 +5,9 @@ import * as _ from "lodash";
 import { uniqWith } from "lodash";
 import {
   Group,
+  GroupedStratificationDto,
   MeasureErrorType,
+  PopulationDto,
   TestCase,
   TestCaseExcelExportDto,
   TestCaseImportOutcome,
@@ -42,13 +44,21 @@ import {
   GroupCoverageResult,
 } from "../../../util/cqlCoverageBuilder/CqlCoverageBuilder";
 import { checkSpecialCharactersForExport } from "../../../util/checkSpecialCharacters";
-import { createExcelExportDtosForAllTestCases } from "../../../util/TestCaseExcelExportUtil";
+import {
+  createExcelExportDtosForAllTestCases,
+  populatePopulationDtos,
+  populateStratificationDtos,
+} from "../../../util/TestCaseExcelExportUtil";
 import useCqlParsingService from "../../../api/useCqlParsingService";
 import { CqlDefinitionCallstack } from "../../editTestCase/groupCoverage/QiCoreGroupCoverage";
 import useExcelExportService from "../../../api/useExcelExportService";
 import FileSaver from "file-saver";
 import { AxiosError, AxiosResponse } from "axios";
 import ExportModal from "./ExportModal";
+import {
+  QrdaTestCaseDTO,
+  QrdaGroupExportDTO,
+} from "../../../api/useTestCaseServiceApi";
 
 export const IMPORT_ERROR =
   "An error occurred while importing your test cases. Please try again, or reach out to the Help Desk.";
@@ -543,62 +553,71 @@ const TestCaseList = (props: TestCaseListProps) => {
   };
 
   const exportQRDA = async () => {
-    setExportExecuting(true);
-    setOptionsOpen(false);
     const failedTCs = checkSpecialCharactersForExport(testCases);
     if (failedTCs.length) {
       setErrors((prevState) => [...prevState, ...failedTCs]);
       return;
     }
-
+    setExportExecuting(true);
+    setOptionsOpen(false);
     const localMeasure = _.cloneDeep(measure);
+    const executionResults: CqmExecutionResultsByPatient = calculationOutput;
+    const groupExportDTOs: QrdaGroupExportDTO[] = [];
+    let groupNumber = 1;
     try {
-      const executionResults: CqmExecutionResultsByPatient = calculationOutput;
       // process calculation results for every population criteria
-      localMeasure.testCases.forEach((testCase) => {
-        const patient: QDMPatient = JSON.parse(testCase.json);
-        const patientResults = executionResults[patient._id];
-        const testCaseWithResults =
-          qdmCalculation.current.processTestCaseResults(
-            testCase,
-            localMeasure.groups,
-            localMeasure,
-            patientResults
+      localMeasure.groups?.forEach((group) => {
+        const testCaseDTOs: QrdaTestCaseDTO[] = [];
+        localMeasure.testCases.forEach((testCase) => {
+          const patient: QDMPatient = JSON.parse(testCase.json);
+          const patientResults = executionResults[patient._id];
+          const testCaseWithResults =
+            qdmCalculation.current.processTestCaseResults(
+              testCase,
+              [group],
+              localMeasure,
+              patientResults
+            );
+          testCase.groupPopulations = testCaseWithResults.groupPopulations;
+          testCase.executionStatus = testCaseWithResults.executionStatus;
+
+          const groupPopulation = testCase.groupPopulations?.find(
+            (groupPopulation) => {
+              return groupPopulation.groupId === group.id;
+            }
           );
-        testCase.groupPopulations = testCaseWithResults.groupPopulations;
-        testCase.executionStatus = testCaseWithResults.executionStatus;
-      });
-      const callstack = await cqlParsingService.current.getDefinitionCallstacks(
-        measure.cql
-      );
-      const excelTestCaseDtos: TestCaseExcelExportDto[] =
-        createExcelExportDtosForAllTestCases(
-          localMeasure,
-          cqmMeasure,
-          calculationOutput,
-          callstack
-        );
-      const testCaseDtos: TestCaseExcelExportDto[] = excelTestCaseDtos.map(
-        (dto) => ({
-          groupId: dto.groupId,
-          groupNumber: dto.groupNumber,
+
+          let stratNumber = 1;
+          const populationDtos: PopulationDto[] =
+            populatePopulationDtos(groupPopulation);
+          const groupedStratDtos: GroupedStratificationDto[] =
+            populateStratificationDtos(
+              groupPopulation,
+              groupNumber,
+              stratNumber,
+              testCase.id
+            );
+          testCaseDTOs.push({
+            testCaseId: testCase.id,
+            lastName: testCase.series,
+            firstName: testCase.title,
+            populations: populationDtos,
+            stratifications: groupedStratDtos,
+          });
+        });
+        groupExportDTOs.push({
+          groupId: group.id,
+          groupNumber: groupNumber.toString(),
           coverage: clauseCoverageProcessor(
-            localMeasure.groups.find((g) => g.id === dto.groupId)
+            localMeasure.groups.find((g) => g.id === group.id)
           ),
-          testCaseExecutionResults: dto.testCaseExecutionResults.map((r) => ({
-            testCaseId: r.testCaseId,
-            populations: r.populations,
-            stratifications: r.stratifications,
-            last: r.last,
-            first: r.first,
-            definitions: [],
-            functions: [],
-          })),
-        })
-      );
+          testCaseDTOs,
+        });
+        groupNumber++;
+      });
       const exportData = await testCaseService.current.exportQRDA(measureId, {
         measure: localMeasure,
-        testCaseDtos,
+        groupDTOs: groupExportDTOs,
       });
       FileSaver.saveAs(
         exportData,

--- a/src/util/TestCaseExcelExportUtil.ts
+++ b/src/util/TestCaseExcelExportUtil.ts
@@ -37,7 +37,7 @@ export const convertToNumber = (value: number | boolean | string) => {
   return convertedNumber;
 };
 
-const populatePopulationDtos = (
+export const populatePopulationDtos = (
   groupPopulation: GroupPopulation
 ): PopulationDto[] => {
   const populationDtos: PopulationDto[] = [];
@@ -83,7 +83,7 @@ const convertToStratDto = (strat): StratificationDto[] => {
 
   return stratificationDtos;
 };
-const populateStratificationDtos = (
+export const populateStratificationDtos = (
   groupPopulation: GroupPopulation,
   groupNumber: number,
   stratNumber: number,


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-6835](https://jira.cms.gov/browse/MAT-6835)
(Optional) Related Tickets:

### Summary

- **MAT-6835: Call QRDA export with DTO.**
- **MAT-6835: Refactor clauseCoverageProcessor:  - Accept Group argument so that it can be run against Groups not currently selected by the user. Defaults to selectedPopCriteria if no arg passed.  - Return Coverage percentage instead of mutating useState var.**
- **MAT-6835: Update local measure group data with calculation results and coverage percentage before passing to QRDA Export service.**
- **MAT-6835: Use QRDA specific DTOs.**

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included
* [ ] No extemporaneous files are included (i.e Complied files or testing results)
* [ ] This PR is into the **correct branch**.
* [ ] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [ ] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
