### PR TITLE
[MAT-7233] Display Errors from VSAC FHIR Term Service

### DIFF
--- a/src/api/useTerminologyServiceApi.ts
+++ b/src/api/useTerminologyServiceApi.ts
@@ -110,14 +110,11 @@ export class TerminologyServiceApi {
     } catch (error) {
       let message =
         "An error occurred, please try again. If the error persists, please contact the help desk. (004)";
-      if (error.response && error.response.status === 404) {
-        const data = error.response.data?.message;
-        console.error(
-          "ValueSet not found in vsac: ",
-          this.getOidFromString(data)
-        );
-        message =
-          "An error exists with the measure CQL, please review the CQL Editor tab.";
+      if (error.response?.data?.diagnostic) {
+        const data = error.response.data;
+        message = `Value Set ${data?.valueSet} could not be expanded using ${
+          data?.manifest === undefined ? "Latest" : "Manifest " + data.manifest
+        }. Per VSAC, \"${data.diagnostic}\"`;
       }
       throw new Error(message);
     }

--- a/src/components/routes/qdm/TestCaseRoutes.tsx
+++ b/src/components/routes/qdm/TestCaseRoutes.tsx
@@ -99,6 +99,13 @@ const TestCaseRoutes = () => {
         setExecutionContextReady(
           !!newCqmMeasure && !_.isEmpty(newCqmMeasure?.value_sets) && !!measure
         );
+        if (cqmMeasureErrors) {
+          setCqmMeasureErrors(
+            cqmMeasureErrors.filter((err) => {
+              !err.includes("VSAC");
+            })
+          );
+        }
       })
       .catch((err) => {
         setContextFailure(true);


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-7233](https://jira.cms.gov/browse/MAT-7233)
(Optional) Related Tickets:

### Summary

- **MAT-7233: Display error message returned from FHIR Term Service to inform the user that the error occurred on VSAC's end.**
- **MAT-7233: Remove VSAC related error message when Expansion config is updated.**

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included
* [ ] No extemporaneous files are included (i.e Complied files or testing results)
* [ ] This PR is into the **correct branch**.
* [ ] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [ ] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
