### PR TITLE
Feature/mat 7338 update measurestore testcases

### DIFF
--- a/.github/workflows/unit_test_coverage.yml
+++ b/.github/workflows/unit_test_coverage.yml
@@ -93,7 +93,8 @@ jobs:
         with:
           name: coverage
       - name: Upload code coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           file: lcov.info
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }} # required

--- a/src/components/routes/qdm/TestCaseRoutes.test.tsx
+++ b/src/components/routes/qdm/TestCaseRoutes.test.tsx
@@ -72,6 +72,7 @@ jest.mock("@madie/madie-util", () => ({
   useDocumentTitle: jest.fn(),
   measureStore: {
     updateMeasure: jest.fn((measure) => measure),
+    updateTestCases: jest.fn().mockImplementation(() => {}),
     state: null,
     initialState: null,
     subscribe: (set) => {

--- a/src/components/routes/qdm/TestCaseRoutes.tsx
+++ b/src/components/routes/qdm/TestCaseRoutes.tsx
@@ -32,6 +32,7 @@ const TestCaseRoutes = () => {
   const cqmService = useRef(useCqmConversionService());
   const terminologyService = useRef(useTerminologyServiceApi());
 
+  const prevMeasureRef = useRef(null);
   const [measure, setMeasure] = useState<Measure>(measureStore.state);
 
   useEffect(() => {
@@ -63,7 +64,18 @@ const TestCaseRoutes = () => {
   ]);
 
   useEffect(() => {
-    if (measure) {
+    // only run updates if measure has changed, ignoring test cases
+    if (
+      _.isNil(prevMeasureRef.current) ||
+      !_.isEqual(
+        {
+          ...measure,
+          testCases: null,
+        },
+        { ...prevMeasureRef.current, testCases: null }
+      )
+    ) {
+      prevMeasureRef.current = measure;
       setContextFailure(null);
       setCqmMeasure(null);
       setExecutionContextReady(false);

--- a/src/components/routes/qiCore/TestCaseRoutes.test.tsx
+++ b/src/components/routes/qiCore/TestCaseRoutes.test.tsx
@@ -75,6 +75,7 @@ jest.mock("@madie/madie-util", () => ({
   useDocumentTitle: jest.fn(),
   measureStore: {
     updateMeasure: jest.fn((measure) => measure),
+    updateTestCases: jest.fn().mockImplementation(() => {}),
     state: null,
     initialState: null,
     subscribe: (set) => {

--- a/src/components/testCaseLanding/common/Hooks/UseTestCases.tsx
+++ b/src/components/testCaseLanding/common/Hooks/UseTestCases.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState, useEffect, useRef } from "react";
 import useTestCaseServiceApi from "../../../../api/useTestCaseServiceApi";
 import { TestCase } from "@madie/madie-models";
+import { measureStore } from "@madie/madie-util";
 import * as _ from "lodash";
 
 function UseFetchTestCases({ measureId, setErrors }) {
@@ -10,8 +11,8 @@ function UseFetchTestCases({ measureId, setErrors }) {
     loading: true,
     message: "",
   });
+  const { updateTestCases } = measureStore;
 
-  // We need testCase.json to be a QDMPatient object for execution
   const retrieveTestCases = useCallback(() => {
     setLoadingState(() => ({
       loading: true,
@@ -24,6 +25,7 @@ function UseFetchTestCases({ measureId, setErrors }) {
           testCase.executionStatus = testCase.validResource ? "NA" : "Invalid";
         });
         testCaseList = _.orderBy(testCaseList, ["lastModifiedAt"], ["desc"]);
+        updateTestCases(testCaseList);
         setTestCases(testCaseList);
       })
       .catch((err) => {
@@ -47,4 +49,5 @@ function UseFetchTestCases({ measureId, setErrors }) {
     retrieveTestCases,
   };
 }
+
 export default UseFetchTestCases;

--- a/src/components/testCaseLanding/qdm/TestCaseList.test.tsx
+++ b/src/components/testCaseLanding/qdm/TestCaseList.test.tsx
@@ -42,7 +42,11 @@ import userEvent from "@testing-library/user-event";
 import { buildMeasureBundle } from "../../../util/CalculationTestHelpers";
 import { QdmExecutionContextProvider } from "../../routes/qdm/QdmExecutionContext";
 // @ts-ignore
-import { checkUserCanEdit, useFeatureFlags } from "@madie/madie-util";
+import {
+  checkUserCanEdit,
+  useFeatureFlags,
+  measureStore,
+} from "@madie/madie-util";
 import qdmCalculationService, {
   QdmCalculationService,
 } from "../../../api/QdmCalculationService";
@@ -115,6 +119,7 @@ jest.mock("@madie/madie-util", () => ({
   checkUserCanEdit: jest.fn().mockImplementation(() => true),
   measureStore: {
     updateMeasure: jest.fn((measure) => measure),
+    updateTestCases: jest.fn().mockImplementation(() => {}),
     state: jest.fn().mockImplementation(() => mockMeasure),
     initialState: null,
     subscribe: (set) => {
@@ -1739,6 +1744,9 @@ describe("TestCaseList component", () => {
     await waitFor(() => {
       const submitButton = screen.queryByText("Yes, Delete");
       expect(submitButton).not.toBeInTheDocument();
+      expect(measureStore.updateTestCases as jest.Mock).toHaveBeenCalledTimes(
+        2
+      );
     });
   });
 
@@ -1803,6 +1811,7 @@ describe("TestCaseList component", () => {
     expect(toastMessage).toHaveTextContent("Test cases successfully deleted");
     expect(screen.queryByTestId("delete-dialog-body")).toBeNull();
     expect(deleteTestCasesApiMock).toHaveBeenCalled();
+    expect(measureStore.updateTestCases as jest.Mock).toHaveBeenCalledTimes(3);
   });
 
   it("Should hide delete all dialogue when cancel is clicked", async () => {

--- a/src/components/testCaseLanding/qdm/TestCaseList.tsx
+++ b/src/components/testCaseLanding/qdm/TestCaseList.tsx
@@ -203,7 +203,9 @@ const TestCaseList = (props: TestCaseListProps) => {
   }, [measure]);
 
   useEffect(() => {
-    retrieveTestCases();
+    if (!_.isNil(measureId) && testCaseService) {
+      retrieveTestCases();
+    }
   }, [measureId, testCaseService]);
 
   useEffect(() => {

--- a/src/components/testCaseLanding/qiCore/TestCaseList.test.tsx
+++ b/src/components/testCaseLanding/qiCore/TestCaseList.test.tsx
@@ -133,6 +133,7 @@ jest.mock("@madie/madie-util", () => ({
   useDocumentTitle: jest.fn(),
   measureStore: {
     updateMeasure: jest.fn((measure) => measure),
+    updateTestCases: jest.fn().mockImplementation(() => {}),
     state: jest.fn().mockImplementation(() => mockMeasure),
     initialState: null,
     subscribe: (set) => {

--- a/src/types/madie-madie-util.d.ts
+++ b/src/types/madie-madie-util.d.ts
@@ -1,6 +1,7 @@
 declare module "@madie/madie-util" {
   import { LifeCycleFn } from "single-spa";
   import { Measure, Acl } from "@madie/madie-models/dist/Measure";
+  import { TestCase } from "@madie/madie-models";
 
   export interface OktaConfig {
     baseUrl: string;
@@ -47,6 +48,7 @@ declare module "@madie/madie-util" {
       setMeasureState: React.Dispatch<React.SetStateAction<Measure>>
     ) => import("rxjs").Subscription;
     updateMeasure: (measure: Measure | null) => void;
+    updateTestCases: (testCases: TestCase[] | null) => void;
     initialState: null;
     state: Measure;
   };


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-7338](https://jira.cms.gov/browse/MAT-7338)
(Optional) Related Tickets:
[MAT-7370](https://jira.cms.gov/browse/MAT-7338)

### Summary
This PR encompasses several changes. Most are around updating the test cases on the measure in the measureStore anytime the test cases are fetched after a user action on the test case list page.
The one change separate from those is only running the data fetching in routes (cqmMeasure conversion, valueset expansion) when the measure changes exclusive of test cases. This is to avoid triggering another fetch of that data anytime a user creates/clones/deletes any test cases. 
This PR should also address the lack of status change of the Delete All button and test case count indicator when creating a new test case, cloning a test case, deleting a single test case, or deleting all test cases.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included
* [x] No extemporaneous files are included (i.e Complied files or testing results)
* [x] This PR is into the **correct branch**.
* [ ] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [ ] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
