### PR TITLE
[MAT-7639] Use single dateTime component for QDM DOB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fortawesome/react-fontawesome": "^0.1.16",
         "@lhncbc/ucum-lhc": "^5.0.0",
         "@madie/cql-antlr-parser": "^1.0.0",
-        "@madie/madie-design-system": "^1.2.29",
+        "@madie/madie-design-system": "^1.2.30",
         "@madie/madie-models": "^1.4.4",
         "@mui/core": "^5.0.0-alpha.54",
         "@mui/icons-material": "^5.8.2",
@@ -3738,10 +3738,9 @@
       }
     },
     "node_modules/@madie/madie-design-system": {
-      "version": "1.2.29",
-      "resolved": "https://registry.npmjs.org/@madie/madie-design-system/-/madie-design-system-1.2.29.tgz",
-      "integrity": "sha512-3Quc8kUotZK8u/hEhPLABJQ0nowZDKBfDk1t4abQBrJ5aTALyueVCo/YSD0hEUNXurwHTShfk74mnLs4UU1tJA==",
-      "license": "CC0-1.0",
+      "version": "1.2.30",
+      "resolved": "https://registry.npmjs.org/@madie/madie-design-system/-/madie-design-system-1.2.30.tgz",
+      "integrity": "sha512-OUhZybxziWY2TEo4+0CfXcxXtYIuqoEcE7FwB4Hy6T9yfUVTS7gqJ1QEcRD7QBui9r//uXoqU3z0Ud3NNch1kg==",
       "dependencies": {
         "@cmsgov/design-system": "^5.0.2",
         "@emotion/react": "^11.8.2",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@fortawesome/react-fontawesome": "^0.1.16",
     "@lhncbc/ucum-lhc": "^5.0.0",
     "@madie/cql-antlr-parser": "^1.0.0",
-    "@madie/madie-design-system": "^1.2.29",
+    "@madie/madie-design-system": "^1.2.30",
     "@madie/madie-models": "^1.4.4",
     "@mui/core": "^5.0.0-alpha.54",
     "@mui/icons-material": "^5.8.2",

--- a/src/components/common/dateTimeInput/DateTimeInput.test.tsx
+++ b/src/components/common/dateTimeInput/DateTimeInput.test.tsx
@@ -19,7 +19,7 @@ describe("DateTimeInput Component", () => {
       />
     );
 
-    expect(screen.getByTestId("author-date-time")).toBeInTheDocument();
+    expect(screen.getByTestId("author-date-time-input")).toBeInTheDocument();
     expect(screen.getByText("Author Date/Time")).toBeInTheDocument();
     expect(screen.getByDisplayValue("04/17/2022 03:30 PM")).toBeInTheDocument();
   });
@@ -35,7 +35,7 @@ describe("DateTimeInput Component", () => {
       />
     );
 
-    expect(screen.getByTestId("author-date-time")).toBeInTheDocument();
+    expect(screen.getByTestId("author-date-time-input")).toBeInTheDocument();
     expect(screen.getByText("Author Date/Time")).toBeInTheDocument();
     const inputValue = screen.getByDisplayValue("04/17/2022 03:30 PM");
     expect(inputValue).toBeInTheDocument();

--- a/src/components/common/dateTimeInput/DateTimeInput.tsx
+++ b/src/components/common/dateTimeInput/DateTimeInput.tsx
@@ -3,6 +3,7 @@ import { DateTimeField } from "@madie/madie-design-system/dist/react";
 import dayjs from "dayjs";
 import { CQL } from "cqm-models";
 import utc from "dayjs/plugin/utc";
+import { kebabCase } from "lodash";
 
 dayjs.extend(utc);
 dayjs.utc();
@@ -66,7 +67,7 @@ const DateTimeInput = ({
   };
   return (
     <DateTimeField
-      id={label}
+      id={kebabCase(label)}
       disabled={!canEdit}
       label={label}
       handleDateTimeChange={handleDateTimeChange}

--- a/src/components/common/dateTimeInput/DateTimeInput.tsx
+++ b/src/components/common/dateTimeInput/DateTimeInput.tsx
@@ -3,8 +3,6 @@ import { DateTimeField } from "@madie/madie-design-system/dist/react";
 import dayjs from "dayjs";
 import { CQL } from "cqm-models";
 import utc from "dayjs/plugin/utc";
-import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
-import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 
 dayjs.extend(utc);
 dayjs.utc();
@@ -67,15 +65,13 @@ const DateTimeInput = ({
     }
   };
   return (
-    <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DateTimeField
-        id={label}
-        disabled={!canEdit}
-        label={label}
-        handleDateTimeChange={handleDateTimeChange}
-        dateTimeValue={toDayJS(dateTime)}
-      />
-    </LocalizationProvider>
+    <DateTimeField
+      id={label}
+      disabled={!canEdit}
+      label={label}
+      handleDateTimeChange={handleDateTimeChange}
+      dateTimeValue={toDayJS(dateTime)}
+    />
   );
 };
 

--- a/src/components/common/dateTimeInterval/DateTimeInterval.test.tsx
+++ b/src/components/common/dateTimeInterval/DateTimeInterval.test.tsx
@@ -26,11 +26,11 @@ describe("DateTimeInterval Field Component", () => {
 
     expect(screen.getByText("Active Period - Start")).toBeInTheDocument();
     expect(screen.getByDisplayValue("04/17/2022 03:30 PM")).toBeInTheDocument();
-    expect(screen.getByTestId("active-period-start")).toBeInTheDocument();
+    expect(screen.getByTestId("active-period-start-input")).toBeInTheDocument();
 
     expect(screen.getByText("Active Period - End")).toBeInTheDocument();
     expect(screen.getByDisplayValue("09/17/2022 03:30 PM")).toBeInTheDocument();
-    expect(screen.getByTestId("active-period-end")).toBeInTheDocument();
+    expect(screen.getByTestId("active-period-end-input")).toBeInTheDocument();
   });
 
   it("Should display changed DateTimeInterval values when input changes", async () => {
@@ -45,12 +45,12 @@ describe("DateTimeInterval Field Component", () => {
     );
 
     expect(screen.getByText("Active Period - Start")).toBeInTheDocument();
-    expect(screen.getByTestId("active-period-start")).toBeInTheDocument();
+    expect(screen.getByTestId("active-period-start-input")).toBeInTheDocument();
     const inputStart = screen.getByDisplayValue("04/17/2022 03:30 PM");
     expect(inputStart).toBeInTheDocument();
 
     expect(screen.getByText("Active Period - End")).toBeInTheDocument();
-    expect(screen.getByTestId("active-period-end")).toBeInTheDocument();
+    expect(screen.getByTestId("active-period-end-input")).toBeInTheDocument();
     const inputEnd = screen.getByDisplayValue("09/17/2022 03:30 PM");
     expect(inputEnd).toBeInTheDocument();
 
@@ -78,12 +78,12 @@ describe("DateTimeInterval Field Component", () => {
     );
 
     expect(screen.getByText("Active Period - Start")).toBeInTheDocument();
-    expect(screen.getByTestId("active-period-start")).toBeInTheDocument();
+    expect(screen.getByTestId("active-period-start-input")).toBeInTheDocument();
     const inputStart = screen.getByDisplayValue("04/17/2022 03:30 PM");
     expect(inputStart).toBeInTheDocument();
 
     expect(screen.getByText("Active Period - End")).toBeInTheDocument();
-    expect(screen.getByTestId("active-period-end")).toBeInTheDocument();
+    expect(screen.getByTestId("active-period-end-input")).toBeInTheDocument();
     const inputEnd = screen.getByDisplayValue("09/17/2022 03:30 PM");
     expect(inputEnd).toBeInTheDocument();
 

--- a/src/components/common/dateTimeInterval/DateTimeInterval.tsx
+++ b/src/components/common/dateTimeInterval/DateTimeInterval.tsx
@@ -25,7 +25,7 @@ const DateTimeInterval = ({
   const handleStartDateTimeChange = (newValue) => {
     if (
       (newValue === null || newValue === undefined) &&
-      !dateTimeInterval.high
+      !dateTimeInterval?.high
     ) {
       onDateTimeIntervalChange(null, attributeName);
     } else {
@@ -41,7 +41,7 @@ const DateTimeInterval = ({
   const handleEndDateTimeChange = (newValue) => {
     if (
       (newValue === null || newValue === undefined) &&
-      !dateTimeInterval.low
+      !dateTimeInterval?.low
     ) {
       onDateTimeIntervalChange(null, attributeName);
     } else {

--- a/src/components/common/facilityLocation/FacilityLocation.test.tsx
+++ b/src/components/common/facilityLocation/FacilityLocation.test.tsx
@@ -63,7 +63,9 @@ describe("FacilityLocation Component", () => {
       />
     );
     expect(screen.getByTestId("value-set-selector")).toBeInTheDocument();
-    expect(screen.getByTestId("location-period-start")).toBeInTheDocument();
-    expect(screen.getByTestId("location-period-end")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("location-period-start-input")
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("location-period-end-input")).toBeInTheDocument();
   });
 });

--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Demographics/DemographicsSection.test.tsx
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Demographics/DemographicsSection.test.tsx
@@ -56,24 +56,15 @@ describe("DemographicsSection", () => {
 
     expect(screen.getByText("Date of Birth")).toBeInTheDocument();
 
-    const birthdateInputs = screen.getAllByPlaceholderText(
-      "MM/DD/YYYY"
+    const birthdateTimeInputs = screen.getAllByLabelText(
+      "Date of Birth"
     ) as HTMLInputElement[];
-    expect(birthdateInputs.length).toBe(1);
-    const birthtimeInputs = screen.getAllByPlaceholderText(
-      "hh:mm aa"
-    ) as HTMLInputElement[];
-    expect(birthtimeInputs.length).toBe(1);
+    expect(birthdateTimeInputs.length).toBe(1);
 
-    fireEvent.change(birthdateInputs[0], {
-      target: { value: "08/02/2023" },
+    fireEvent.change(birthdateTimeInputs[0], {
+      target: { value: "08/02/2023 11:00 AM" },
     });
-    expect(birthdateInputs[0].value).toBe("08/02/2023");
-
-    fireEvent.change(birthtimeInputs[0], {
-      target: { value: "02:24 PM" },
-    });
-    expect(birthtimeInputs[0].value).toBe("02:24 PM");
+    expect(birthdateTimeInputs[0].value).toBe("08/02/2023 11:00 AM");
     await waitFor(() => {
       expect(mockUseQdmPatientDispatch).toHaveBeenLastCalledWith({
         type: PatientActionType.SET_BIRTHDATETIME,
@@ -103,8 +94,8 @@ describe("DemographicsSection", () => {
 
     expect(screen.getByText("Date/Time Expiration")).toBeInTheDocument();
 
-    const dateTimeExpiration = screen.getAllByPlaceholderText(
-      "MM/DD/YYYY hh:mm aa"
+    const dateTimeExpiration = screen.getAllByLabelText(
+      "Date/Time Expiration"
     ) as HTMLInputElement[];
     expect(dateTimeExpiration.length).toBe(1);
     // start date

--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Demographics/DemographicsSection.tsx
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Demographics/DemographicsSection.tsx
@@ -1,22 +1,14 @@
 import React, { useEffect, useState } from "react";
 import ElementSection from "../../../../../common/ElementSection";
-import { InputLabel, Select } from "@madie/madie-design-system/dist/react";
+import { Select } from "@madie/madie-design-system/dist/react";
 import FormControl from "@mui/material/FormControl";
 import {
   DataElement,
   QDMPatient,
   PatientCharacteristicExpired,
 } from "cqm-models";
-import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
-import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
-import { DatePicker } from "@mui/x-date-pickers/DatePicker";
-import { TimePicker } from "@mui/x-date-pickers";
+import DateTimeInput from "../../../../../common/dateTimeInput/DateTimeInput";
 import dayjs from "dayjs";
-import {
-  birthDateLabelStyle,
-  textFieldStyle,
-  timeTextFieldStyle,
-} from "./DemographicsSectionStyles";
 import "./DemographicsSection.scss";
 import utc from "dayjs/plugin/utc";
 
@@ -37,7 +29,6 @@ import {
   PatientActionType,
   useQdmPatient,
 } from "../../../../../../util/QdmPatientContext";
-import DateTimeInput from "../../../../../common/dateTimeInput/DateTimeInput";
 
 export interface CodeSystem {
   code: string;
@@ -228,66 +219,17 @@ const DemographicsSection = ({ canEdit }) => {
           <div className="demographics-container">
             {/* container */}
             <div className="demographics-row">
-              <div className="birth-date">
-                <FormControl>
-                  <LocalizationProvider dateAdapter={AdapterDayjs}>
-                    <InputLabel
-                      htmlFor={"birth-date"}
-                      style={{ marginBottom: 0, height: 16 }} // force a heignt
-                      sx={birthDateLabelStyle}
-                    >
-                      Date of Birth
-                    </InputLabel>
-                    <div style={{ display: "flex" }}>
-                      <DatePicker
-                        disabled={!canEdit}
-                        value={
-                          patient?.birthDatetime
-                            ? dayjs(patient?.birthDatetime)
-                            : null
-                        }
-                        onChange={(newValue: any) => {
-                          const currentDate = dayjs(patient?.birthDatetime);
-                          const newDate = dayjs(currentDate)
-                            .set("year", newValue?.$y)
-                            .set("month", newValue?.$M)
-                            .set("date", newValue?.$D);
-
-                          handleTimeChange(newDate);
-                        }}
-                        slotProps={{
-                          textField: {
-                            id: "birth-date",
-                            sx: textFieldStyle,
-                          },
-                        }}
-                      />
-                      <TimePicker
-                        disableOpenPicker
-                        disabled={!canEdit}
-                        value={
-                          patient?.birthDatetime
-                            ? dayjs(patient?.birthDatetime)
-                            : null
-                        }
-                        onChange={(newValue: any, v) => {
-                          const currentDate = patient?.birthDatetime;
-                          // hours and minute seem to already take into account AMPM
-                          const newDate = dayjs(currentDate)
-                            .set("hour", newValue?.$H)
-                            .set("minute", newValue?.$m);
-                          handleTimeChange(newDate);
-                        }}
-                        slotProps={{
-                          textField: {
-                            sx: timeTextFieldStyle,
-                          },
-                        }}
-                      />
-                    </div>
-                  </LocalizationProvider>
-                </FormControl>
-              </div>
+              <DateTimeInput
+                label="Date of Birth"
+                canEdit={canEdit}
+                dateTime={
+                  patient?.birthDatetime ? dayjs(patient?.birthDatetime) : null
+                }
+                attributeName="DateTime"
+                onDateTimeChange={(newValue) => {
+                  handleTimeChange(newValue);
+                }}
+              />
               <FormControl>
                 <Select
                   labelId="demographics-living-status-select-label"

--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsCard/DataElementsCard.scss
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsCard/DataElementsCard.scss
@@ -34,6 +34,7 @@ $grey-19: #ddd;
     font-size: 18px;
     font-weight: 500;
     color: #125496;
+    margin-bottom: 20px;
   }
   > .timing {
     margin-top: 40px;

--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsCard/timing/Timing.test.tsx
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsCard/timing/Timing.test.tsx
@@ -55,14 +55,16 @@ describe("Timing", () => {
       />
     );
 
-    expect(screen.getByTestId("relevant-period-start")).toBeInTheDocument();
-    expect(screen.getByTestId("relevant-period-end")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("relevant-period-start-input")
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("relevant-period-end-input")).toBeInTheDocument();
     expect(screen.queryByText("Relevant Period - Start")).toBeInTheDocument();
     expect(screen.queryByText("Relevant Period - End")).toBeInTheDocument();
-    expect(screen.getByTestId("relevant-datetime")).toBeInTheDocument();
+    expect(screen.getByTestId("relevant-datetime-input")).toBeInTheDocument();
     expect(screen.queryByText("Relevant Datetime")).toBeInTheDocument();
 
-    expect(screen.getByTestId("author-datetime")).toBeInTheDocument();
+    expect(screen.getByTestId("author-datetime-input")).toBeInTheDocument();
     expect(screen.queryByText("Author Datetime")).toBeInTheDocument();
   });
 
@@ -77,8 +79,12 @@ describe("Timing", () => {
       />
     );
 
-    expect(screen.getByTestId("prevalence-period-start")).toBeInTheDocument();
-    expect(screen.getByTestId("prevalence-period-end")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("prevalence-period-start-input")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("prevalence-period-end-input")
+    ).toBeInTheDocument();
     expect(screen.getByText("Prevalence Period - Start")).toBeInTheDocument();
     expect(screen.getByText("Prevalence Period - End")).toBeInTheDocument();
   });
@@ -95,9 +101,11 @@ describe("Timing", () => {
     );
 
     expect(
-      screen.getByTestId("participation-period-start")
+      screen.getByTestId("participation-period-start-input")
     ).toBeInTheDocument();
-    expect(screen.getByTestId("participation-period-end")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("participation-period-end-input")
+    ).toBeInTheDocument();
     expect(
       screen.getByText("Participation Period - Start")
     ).toBeInTheDocument();
@@ -116,17 +124,19 @@ describe("Timing", () => {
       />
     );
 
-    expect(screen.getByTestId("relevant-period-start")).toBeInTheDocument();
-    expect(screen.getByTestId("relevant-period-end")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("relevant-period-start-input")
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("relevant-period-end-input")).toBeInTheDocument();
     expect(screen.queryByText("Relevant Period - Start")).toBeInTheDocument();
     expect(screen.queryByText("Relevant Period - End")).toBeInTheDocument();
 
-    expect(screen.getByTestId("relevant-datetime")).toBeInTheDocument();
+    expect(screen.getByTestId("relevant-datetime-input")).toBeInTheDocument();
     expect(screen.queryByText("Relevant Datetime")).toBeInTheDocument();
-    expect(screen.getByTestId("author-datetime")).toBeInTheDocument();
+    expect(screen.getByTestId("author-datetime-input")).toBeInTheDocument();
     expect(screen.queryByText("Author Datetime")).toBeInTheDocument();
 
-    expect(screen.getByTestId("result-datetime")).toBeInTheDocument();
+    expect(screen.getByTestId("result-datetime-input")).toBeInTheDocument();
     expect(screen.queryByText("Result Datetime")).toBeInTheDocument();
   });
 
@@ -141,8 +151,12 @@ describe("Timing", () => {
       />
     );
 
-    expect(screen.getByTestId("prevalence-period-start")).toBeInTheDocument();
-    expect(screen.getByTestId("prevalence-period-end")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("prevalence-period-start-input")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("prevalence-period-end-input")
+    ).toBeInTheDocument();
     expect(screen.getByText("Prevalence Period - Start")).toBeInTheDocument();
     expect(screen.getByText("Prevalence Period - End")).toBeInTheDocument();
 
@@ -172,9 +186,11 @@ describe("Timing", () => {
     );
 
     expect(
-      screen.getByTestId("participation-period-start")
+      screen.getByTestId("participation-period-start-input")
     ).toBeInTheDocument();
-    expect(screen.getByTestId("participation-period-end")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("participation-period-end-input")
+    ).toBeInTheDocument();
     expect(
       screen.getByText("Participation Period - Start")
     ).toBeInTheDocument();
@@ -242,8 +258,12 @@ describe("Timing", () => {
       />
     );
 
-    expect(screen.getByTestId("prevalence-period-start")).toBeInTheDocument();
-    expect(screen.getByTestId("prevalence-period-end")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("prevalence-period-start-input")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("prevalence-period-end-input")
+    ).toBeInTheDocument();
     expect(screen.getByText("Prevalence Period - Start")).toBeInTheDocument();
     expect(screen.getByText("Prevalence Period - End")).toBeInTheDocument();
 


### PR DESCRIPTION
 ## MADiE PR

Jira Ticket: [MAT-7639](https://jira.cms.gov/browse/MAT-7639)
(Optional) Related Tickets:

### Summary

- **MAT-7639: Bump design system for updates to DateTimeField.**
- **MAT-7639: Remove extra LocalizationProvider in local component as it is provided by the wrapped design system component.**
- **MAT-7639: Safe nav interval dateTimes to prevent errors with partial entries.**
- **MAT-7639: Add some whitespace between Timing header and fields.**
- **MAT-7639: Replace double DOB fields (DOB and Time of birth) with single DateTime field.**

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included
* [ ] No extemporaneous files are included (i.e Complied files or testing results)
* [ ] This PR is into the **correct branch**.
* [ ] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [ ] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
