### PR TITLE
MAT-7665: Reset the Element card tab to Codes whenever navigating to another card.

### DIFF
--- a/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/ElementsSection.tsx
+++ b/src/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/ElementsSection.tsx
@@ -133,6 +133,8 @@ const ElementsSection = (props: {
     const modelClass = getDataElementClass(sourceCriteria);
     const newDataElement = new modelClass(data);
     setSelectedDataElement(newDataElement);
+    // default to codes tab when adding a new card.
+    setCardActiveTab("codes");
     dispatch({
       type: PatientActionType.ADD_DATA_ELEMENT,
       payload: newDataElement,
@@ -208,6 +210,7 @@ const ElementsSection = (props: {
             const updatedDataElement = new modelClass(dataElement);
             setSelectedDataElement(updatedDataElement);
             setActiveTab(updatedDataElement?.qdmCategory);
+            setCardActiveTab("codes"); // reset element card tab
           }}
           canEdit={canEdit}
           onDelete={deleteDataElement}


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-7665](https://jira.cms.gov/browse/MAT-7665)
(Optional) Related Tickets:

### Summary

Set the active card tab to `codes` whenever navigating to another Card. Doing so ensures unsupported tab displays (namely Negation Rationale) are not visible post-navigation.

Before this change, a user would navigate to the Negation Rationale tab, either make a change or not, then move to an another Data Element or add a new one. If that target Data Element Card didn't support Negation Rationale, no Card tab would be selected and the ValueSet dropdown from Negation Rationale would still be displayed.

![Screenshot 2024-09-24 at 4 05 33 PM](https://github.com/user-attachments/assets/58eceebd-0614-4472-aec8-d883409248e8)

After this change, any navigation to another Data Element will reset the Card Active Tab to `Codes`.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included
* [ ] No extemporaneous files are included (i.e Complied files or testing results)
* [ ] This PR is into the **correct branch**.
* [ ] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [ ] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
